### PR TITLE
Set up ci for python{2,3}

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       - run:
           name: Update cmake
           command: |
+            # https://askubuntu.com/a/865294
             version=3.12
             build=2
             mkdir ~/temp
@@ -62,6 +63,32 @@ jobs:
               aws s3 cp $S3_BASE_URL/dujour/$CIRCLE_BUILD_NUM/ $S3_BASE_URL/latest/ --recursive --acl public-read
             fi
 
+  build_py2:
+    docker:
+      - image: ubuntu:18.10
+    steps:
+      - run: apt update
+      - run: apt install -y git python2 python2-dev python-pip uuid uuid-dev cmake clang
+      - checkout
+      - run: git submodule update --init
+      - run: python2 --version
+      - run: python2 -m pip install -U pip setuptools
+      - run: cmake --version
+      - run: cd src && python2 build_python_lib.py
+
+  build_py3:
+    docker:
+      - image: ubuntu:18.10
+    steps:
+      - run: apt update
+      - run: apt install -y git python3 python3-dev python3-pip uuid uuid-dev cmake clang
+      - checkout
+      - run: git submodule update --init
+      - run: python3 --version
+      - run: python3 -m pip install -U pip setuptools
+      - run: cmake --version
+      - run: cd src && python3 build_python_lib.py 
+
 workflows:
   version: 2
   build:
@@ -70,3 +97,5 @@ workflows:
       - deploy_js:
           requires:
             - build_js
+      - build_py2
+      - build_py3

--- a/src/build_python_lib.py
+++ b/src/build_python_lib.py
@@ -28,8 +28,10 @@ def compilebinaries():
                 print(line.replace("WIN32;", "WIN64;"))
         os.system("cmake --build . --config Release --target _rhino3dm")
     else:
-        os.system("cmake -DPYTHON_EXECUTABLE:FILEPATH={} ../..".format(sys.executable))
-        os.system("make")
+        rv = os.system("cmake -DPYTHON_EXECUTABLE:FILEPATH={} ../..".format(sys.executable))
+        if int(rv) > 0: sys.exit(1)
+        rv = os.system("make")
+        if int(rv) > 0: sys.exit(1)
     os.chdir("../..")
 
 def createwheel():
@@ -57,7 +59,8 @@ def createwheel():
     #platform is found with distutils.util.get_platform()
     python_tag = "cp{}{}".format(sys.version_info.major, sys.version_info.minor)
     options = "--python-tag={} --plat-name={}".format(python_tag, distutils.util.get_platform())
-    os.system('"' + sys.executable + '"' + " setup.py bdist_wheel " + options)
+    rv = os.system('"' + sys.executable + '"' + " setup.py bdist_wheel " + options)
+    if int(rv) > 0: sys.exit(1)
     os.chdir(current_dir+"/build")
     if not os.path.exists("wheels_for_pypi"):
         os.mkdir("wheels_for_pypi")


### PR DESCRIPTION
Builds rhino3dm.py using an Ubuntu 18.10 image on CircleCI

Closes COMPUTE-29