### PR TITLE
Add __iter__ support for tables.

### DIFF
--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -383,9 +383,9 @@ BND_FileObject* BND_ONXModel_ObjectTable::ModelObjectAt(int index)
 }
 
 // helper function for iterator
-BND_CommonObject* BND_ONXModel_ObjectTable::FindIndex(int index)
+BND_FileObject* BND_ONXModel_ObjectTable::IterIndex(int index)
 {
-  return ObjectAt(index);
+  return ModelObjectAt(index);
 }
 
 BND_CommonObject* BND_ONXModel_ObjectTable::ObjectAt(int index)
@@ -438,6 +438,11 @@ void BND_File3dmMaterialTable::Add(const BND_Material& material)
   m_model->AddModelComponent(*m);
 }
 
+BND_Material* BND_File3dmMaterialTable::IterIndex(int index)
+{
+  return FindIndex(index);
+}
+
 BND_Material* BND_File3dmMaterialTable::FindIndex(int index)
 {
   ON_ModelComponentReference compref = m_model->RenderMaterialFromIndex(index);
@@ -484,6 +489,11 @@ BND_Layer* BND_File3dmLayerTable::FindName(std::wstring name, BND_UUID parentId)
   return nullptr;
 }
 
+BND_Layer* BND_File3dmLayerTable::IterIndex(int index)
+{
+  return FindIndex(index);
+}
+
 BND_Layer* BND_File3dmLayerTable::FindIndex(int index)
 {
   ON_ModelComponentReference compref = m_model->LayerFromIndex(index);
@@ -519,7 +529,7 @@ BND_ViewInfo* BND_File3dmViewTable::GetItem(int index) const
   return rc;
 }
 
-BND_ViewInfo* BND_File3dmViewTable::FindIndex(int index) const
+BND_ViewInfo* BND_File3dmViewTable::IterIndex(int index) const
 {
   return GetItem(index);
 }
@@ -689,7 +699,7 @@ struct PyBNDIterator {
 
   ET next() {
     if(index>=seq.Count()) throw py::stop_iteration();
-    return const_cast<IT>(seq).FindIndex(index++);
+    return const_cast<IT>(seq).IterIndex(index++);
   }
 
   const IT seq;
@@ -721,15 +731,15 @@ void initExtensionsBindings(pybind11::module& m)
     .def_property_readonly("Geometry", &BND_FileObject::GetGeometry)
     ;
 
-  py::class_<PyBNDIterator<BND_ONXModel_ObjectTable&, BND_CommonObject*> >(m, "ObjectIterator")
-    .def("__iter__", [](PyBNDIterator<BND_ONXModel_ObjectTable&, BND_CommonObject*> &it) -> PyBNDIterator<BND_ONXModel_ObjectTable&, BND_CommonObject*>& { return it; })
-    .def("__next__", &PyBNDIterator<BND_ONXModel_ObjectTable&, BND_CommonObject*>::next)
+  py::class_<PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*> >(m, "ObjectIterator")
+    .def("__iter__", [](PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*> &it) -> PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*>& { return it; })
+    .def("__next__", &PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*>::next)
     ;
 
   py::class_<BND_ONXModel_ObjectTable>(m, "File3dmObjectTable")
     .def("__len__", &BND_ONXModel_ObjectTable::Count)
     .def("__getitem__", &BND_ONXModel_ObjectTable::ModelObjectAt)
-    .def("__iter__", [](py::object s) { return PyBNDIterator<BND_ONXModel_ObjectTable&, BND_CommonObject*>(s.cast<BND_ONXModel_ObjectTable &>(), s); })
+    .def("__iter__", [](py::object s) { return PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*>(s.cast<BND_ONXModel_ObjectTable &>(), s); })
     .def("AddPoint", &BND_ONXModel_ObjectTable::AddPoint1, py::arg("x"), py::arg("y"), py::arg("z"))
     .def("AddPoint", &BND_ONXModel_ObjectTable::AddPoint2, py::arg("point"))
     .def("AddPoint", &BND_ONXModel_ObjectTable::AddPoint4, py::arg("point"))

--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -704,7 +704,7 @@ struct PyBNDIterator {
 
   const IT seq;
   py::object ref;
-  size_t index = 0;
+  int index = 0;
 };
 
 #endif
@@ -731,7 +731,7 @@ void initExtensionsBindings(pybind11::module& m)
     .def_property_readonly("Geometry", &BND_FileObject::GetGeometry)
     ;
 
-  py::class_<PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*> >(m, "ObjectIterator")
+  py::class_<PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*> >(m, "__ObjectIterator")
     .def("__iter__", [](PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*> &it) -> PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*>& { return it; })
     .def("__next__", &PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*>::next)
     ;
@@ -762,7 +762,7 @@ void initExtensionsBindings(pybind11::module& m)
     .def("Delete", &BND_ONXModel_ObjectTable::Delete)
     ;
 
-  py::class_<PyBNDIterator<BND_File3dmMaterialTable&, BND_Material*> >(m, "MaterialIterator")
+  py::class_<PyBNDIterator<BND_File3dmMaterialTable&, BND_Material*> >(m, "__MaterialIterator")
     .def("__iter__", [](PyBNDIterator<BND_File3dmMaterialTable&, BND_Material*>  &it) -> PyBNDIterator<BND_File3dmMaterialTable&, BND_Material*> & { return it; })
     .def("__next__", &PyBNDIterator<BND_File3dmMaterialTable&, BND_Material*> ::next)
     ;
@@ -776,7 +776,7 @@ void initExtensionsBindings(pybind11::module& m)
     .def("FindId", &BND_File3dmMaterialTable::FindId, py::arg("id"))
     ;
 
-  py::class_<PyBNDIterator<BND_File3dmLayerTable&, BND_Layer*> >(m, "LayerIterator")
+  py::class_<PyBNDIterator<BND_File3dmLayerTable&, BND_Layer*> >(m, "__LayerIterator")
     .def("__iter__", [](PyBNDIterator<BND_File3dmLayerTable&, BND_Layer*> &it) -> PyBNDIterator<BND_File3dmLayerTable&, BND_Layer*>& { return it; })
     .def("__next__", &PyBNDIterator<BND_File3dmLayerTable&, BND_Layer*>::next)
     ;
@@ -791,7 +791,7 @@ void initExtensionsBindings(pybind11::module& m)
     .def("FindId", &BND_File3dmLayerTable::FindId, py::arg("id"))
     ;
 
-  py::class_<PyBNDIterator<BND_File3dmViewTable&, BND_ViewInfo*> >(m, "ViewIterator")
+  py::class_<PyBNDIterator<BND_File3dmViewTable&, BND_ViewInfo*> >(m, "__ViewIterator")
     .def("__iter__", [](PyBNDIterator<BND_File3dmViewTable&, BND_ViewInfo*> &it) -> PyBNDIterator<BND_File3dmViewTable&, BND_ViewInfo*>& { return it; })
     .def("__next__", &PyBNDIterator<BND_File3dmViewTable&, BND_ViewInfo*>::next)
     ;

--- a/src/bindings/bnd_extensions.h
+++ b/src/bindings/bnd_extensions.h
@@ -79,6 +79,7 @@ public:
 
   int Count() const;
   BND_FileObject* ModelObjectAt(int index);
+  BND_CommonObject* FindIndex(int index); // helper function for iterator
   BND_CommonObject* ObjectAt(int index);
   BND_3dmObjectAttributes* AttributesAt(int index);
   BND_BoundingBox GetBoundingBox() const;
@@ -116,6 +117,7 @@ public:
   int Count() const { return m_model->m_settings.m_views.Count(); }
   void Add(const class BND_ViewInfo& view);
   class BND_ViewInfo* GetItem(int index) const;
+  class BND_ViewInfo* FindIndex(int index) const; // helper function for iterator
   void SetItem(int index, const class BND_ViewInfo& view);
 };
 

--- a/src/bindings/bnd_extensions.h
+++ b/src/bindings/bnd_extensions.h
@@ -79,7 +79,7 @@ public:
 
   int Count() const;
   BND_FileObject* ModelObjectAt(int index);
-  BND_CommonObject* FindIndex(int index); // helper function for iterator
+  BND_FileObject* IterIndex(int index); // helper function for iterator
   BND_CommonObject* ObjectAt(int index);
   BND_3dmObjectAttributes* AttributesAt(int index);
   BND_BoundingBox GetBoundingBox() const;
@@ -93,6 +93,7 @@ public:
   int Count() const { return m_model->ActiveComponentCount(ON_ModelComponent::Type::RenderMaterial); }
   void Add(const class BND_Material& material);
   class BND_Material* FindIndex(int index);
+  class BND_Material* IterIndex(int index); // helper function for iterator
   class BND_Material* FindId(BND_UUID id);
 };
 
@@ -106,6 +107,7 @@ public:
   class BND_Layer* FindName(std::wstring name, BND_UUID parentId);
   //BND_Layer* FindNameHash(NameHash nameHash)
   class BND_Layer* FindIndex(int index);
+  class BND_Layer* IterIndex(int index); // helper function for iterator
   class BND_Layer* FindId(BND_UUID id);
 };
 
@@ -117,7 +119,7 @@ public:
   int Count() const { return m_model->m_settings.m_views.Count(); }
   void Add(const class BND_ViewInfo& view);
   class BND_ViewInfo* GetItem(int index) const;
-  class BND_ViewInfo* FindIndex(int index) const; // helper function for iterator
+  class BND_ViewInfo* IterIndex(int index) const; // helper function for iterator
   void SetItem(int index, const class BND_ViewInfo& view);
 };
 


### PR DESCRIPTION
The tables supported are Layers, Materials
Objects and Views.

* Introduce a templated iterator struct
* Add FindIndex() helper functions to tables that
  don't have them yet

More tables can be added as necessary.