### PR TITLE
Wrap ON::UnitScale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@
 *.out
 *.app
 
+.vscode
+
 /.vs
 *.vcxproj.user
 /python/wheels_for_pypi

--- a/src/bindings/bnd_defines.cpp
+++ b/src/bindings/bnd_defines.cpp
@@ -139,6 +139,7 @@ void initDefines(pybind11::module& m)
     .value("Parsecs", ON::LengthUnitSystem::Parsecs)
     .value("CustomUnits", ON::LengthUnitSystem::CustomUnits)
     .value("Unset", ON::LengthUnitSystem::Unset)
+    .def_static("UnitScale", [](ON::LengthUnitSystem a, ON::LengthUnitSystem b) { return ON::UnitScale(a, b);})
     ;
 }
 

--- a/src/pysrc/setup.py
+++ b/src/pysrc/setup.py
@@ -13,7 +13,7 @@ def create_package_list(base_package):
 
 setuptools.setup(
     name="rhino3dm",
-    version="0.1.4",
+    version="0.1.5",
     author="Robert McNeel & Associates",
     author_email="steve@mcneel.com",
     description="OpenNURBS based package with a RhinoCommon style",


### PR DESCRIPTION
Wrapping ON::UnitScale makes it easy to get the scale factor between
the different length unit systems so that it stays consistent with Rhino.