### PR TITLE
Fixups for Mesh and NurbsCurve

### DIFF
--- a/src/bindings/bnd_mesh.h
+++ b/src/bindings/bnd_mesh.h
@@ -17,10 +17,10 @@ public:
   BND_MeshingParameters(double density, double minimumEdgeLength) : m_mesh_parameters(density, minimumEdgeLength) {}
   BND_MeshingParameters(const ON_MeshParameters& mp) : m_mesh_parameters(mp) {}
 
-  static BND_MeshingParameters Default() { return BND_MeshingParameters(ON_MeshParameters::DefaultMesh); }
-  static BND_MeshingParameters FastRenderMesh() { return BND_MeshingParameters(ON_MeshParameters::FastRenderMesh); }
-  static BND_MeshingParameters QualityRenderMesh() { return BND_MeshingParameters(ON_MeshParameters::QualityRenderMesh); }
-  static BND_MeshingParameters DefaultAnalysisMesh() { return BND_MeshingParameters(ON_MeshParameters::DefaultAnalysisMesh); }
+  static BND_MeshingParameters Default(pybind11::object /*self*/) { return BND_MeshingParameters(ON_MeshParameters::DefaultMesh); }
+  static BND_MeshingParameters FastRenderMesh(pybind11::object /*self*/) { return BND_MeshingParameters(ON_MeshParameters::FastRenderMesh); }
+  static BND_MeshingParameters QualityRenderMesh(pybind11::object /*self*/) { return BND_MeshingParameters(ON_MeshParameters::QualityRenderMesh); }
+  static BND_MeshingParameters DefaultAnalysisMesh(pybind11::object /*self*/) { return BND_MeshingParameters(ON_MeshParameters::DefaultAnalysisMesh); }
 
   //public MeshingParameterTextureRange TextureRange | getset
   int GetTextureRange() const { return m_mesh_parameters.TextureRange(); }

--- a/src/bindings/bnd_mesh.h
+++ b/src/bindings/bnd_mesh.h
@@ -17,10 +17,17 @@ public:
   BND_MeshingParameters(double density, double minimumEdgeLength) : m_mesh_parameters(density, minimumEdgeLength) {}
   BND_MeshingParameters(const ON_MeshParameters& mp) : m_mesh_parameters(mp) {}
 
+#if defined(ON_PYTHON_COMPILE)
   static BND_MeshingParameters Default(pybind11::object /*self*/) { return BND_MeshingParameters(ON_MeshParameters::DefaultMesh); }
   static BND_MeshingParameters FastRenderMesh(pybind11::object /*self*/) { return BND_MeshingParameters(ON_MeshParameters::FastRenderMesh); }
   static BND_MeshingParameters QualityRenderMesh(pybind11::object /*self*/) { return BND_MeshingParameters(ON_MeshParameters::QualityRenderMesh); }
   static BND_MeshingParameters DefaultAnalysisMesh(pybind11::object /*self*/) { return BND_MeshingParameters(ON_MeshParameters::DefaultAnalysisMesh); }
+#else
+  static BND_MeshingParameters Default() { return BND_MeshingParameters(ON_MeshParameters::DefaultMesh); }
+  static BND_MeshingParameters FastRenderMesh() { return BND_MeshingParameters(ON_MeshParameters::FastRenderMesh); }
+  static BND_MeshingParameters QualityRenderMesh() { return BND_MeshingParameters(ON_MeshParameters::QualityRenderMesh); }
+  static BND_MeshingParameters DefaultAnalysisMesh() { return BND_MeshingParameters(ON_MeshParameters::DefaultAnalysisMesh); }
+#endif
 
   //public MeshingParameterTextureRange TextureRange | getset
   int GetTextureRange() const { return m_mesh_parameters.TextureRange(); }

--- a/src/bindings/bnd_nurbscurve.cpp
+++ b/src/bindings/bnd_nurbscurve.cpp
@@ -184,6 +184,8 @@ void initNurbsCurveBindings(pybind11::module& m)
     .def("Reparameterize", &BND_NurbsCurve::Reparameterize)
     .def("GrevilleParameter", &BND_NurbsCurve::GrevilleParameter, py::arg("index"))
     .def("GrevillePoint", &BND_NurbsCurve::GrevillePoint, py::arg("index"))
+    .def_property_readonly("Points", &BND_NurbsCurve::Points)
+    .def_property_readonly("Knots", &BND_NurbsCurve::Knots)
     ;
 }
 #endif


### PR DESCRIPTION
* Mesh needed proper function signature for getter functions to static, readonly properties
* Expose NurbsCurve Points and Knots accessors.