### PR TITLE
Improved version check py2 vs py3

### DIFF
--- a/src/rhino3dm/__init__.py
+++ b/src/rhino3dm/__init__.py
@@ -1,8 +1,8 @@
 import sys
-if sys.version_info.major==3:
-    from ._rhino3dm import *
-else:
+if sys.version_info.major==2:
     from _rhino3dm import *
+else:
+    from ._rhino3dm import *
 
 __version__ = '0.5.0'
 


### PR DESCRIPTION
As per https://github.com/asottile/flake8-2020
The next version of python after 3.9 could be python 4.0, in which case the python 3 code should run, not python 2.  Alpha versions may come out in 2020 so this will come around pretty quickly.