### PR TITLE
implements BND_InstanceDefinitionGeometry.GetObjectIds(), exposes .Name and .Id

### DIFF
--- a/src/bindings/bnd_instance.cpp
+++ b/src/bindings/bnd_instance.cpp
@@ -3,6 +3,7 @@
 BND_InstanceDefinitionGeometry::BND_InstanceDefinitionGeometry(ON_InstanceDefinition* idef, const ON_ModelComponentReference* compref)
 {
   SetTrackedPointer(idef, compref);
+  m_guids = ON_SimpleArrayUUID_to_Binding(idef->InstanceGeometryIdList());
 }
 
 void BND_InstanceDefinitionGeometry::SetTrackedPointer(ON_InstanceDefinition* idef, const ON_ModelComponentReference* compref)
@@ -55,6 +56,9 @@ void initInstanceBindings(pybind11::module& m)
   py::class_<BND_InstanceDefinitionGeometry, BND_CommonObject>(m, "InstanceDefinition")
     .def(py::init<>())
     .def_property_readonly("Description", &BND_InstanceDefinitionGeometry::Description)
+	.def_property_readonly("Name", &BND_InstanceDefinitionGeometry::Name)
+	.def_property_readonly("Id", &BND_InstanceDefinitionGeometry::Id)
+	.def("GetObjectIds", &BND_InstanceDefinitionGeometry::GetObjectIds)
     ;
 
   py::class_<BND_InstanceReferenceGeometry, BND_GeometryBase>(m, "InstanceReference")
@@ -62,6 +66,14 @@ void initInstanceBindings(pybind11::module& m)
     .def_property_readonly("ParentIdefId", &BND_InstanceReferenceGeometry::ParentIdefId)
     .def_property_readonly("Xform", &BND_InstanceReferenceGeometry::Xform)
     ;
+  //bind opaque std::vector<BND_UUID> and provide functionality (acts ~like a python list)
+  py::class_<std::vector<BND_UUID>>(m, "GuidList")
+	.def(py::init<>())
+	.def("__len__", [](const std::vector<BND_UUID>& self) { return self.size(); })
+	.def("__getitem__", [](const std::vector<BND_UUID>& self, const unsigned int i) { return self[i]; })
+	.def("__iter__", [](std::vector<BND_UUID>& self) {
+			return py::make_iterator(self.begin(), self.end());
+			}, py::keep_alive<0, 1>());
 }
 #endif
 

--- a/src/bindings/bnd_instance.h
+++ b/src/bindings/bnd_instance.h
@@ -12,6 +12,7 @@ class BND_InstanceDefinitionGeometry : public BND_CommonObject
 {
 public:
   ON_InstanceDefinition* m_idef = nullptr;
+  std::vector<BND_UUID> m_guids;
 protected:
   void SetTrackedPointer(ON_InstanceDefinition* idef, const ON_ModelComponentReference* compref);
 
@@ -19,7 +20,10 @@ public:
   BND_InstanceDefinitionGeometry(ON_InstanceDefinition* idef, const ON_ModelComponentReference* compref);
   BND_InstanceDefinitionGeometry();
   std::wstring Description() const { return std::wstring(m_idef->Description()); }
+  std::wstring Name() const { return std::wstring(m_idef->Name()); }
+  BND_UUID Id() const { return ON_UUID_to_Binding(m_idef->Id()); }
   //public Guid[] GetObjectIds()
+  std::vector<BND_UUID>& GetObjectIds() { return m_guids; };
 };
 
 class BND_InstanceReferenceGeometry : public BND_GeometryBase

--- a/src/bindings/bnd_uuid.cpp
+++ b/src/bindings/bnd_uuid.cpp
@@ -24,6 +24,16 @@ ON_UUID Binding_to_ON_UUID(const BND_UUID& id)
   return ON_UuidFromString(s.c_str());
 }
 
+std::vector<BND_UUID> ON_SimpleArrayUUID_to_Binding(const ON_SimpleArray<ON_UUID>& uuids)
+{
+	std::vector<BND_UUID> guids;
+	for (int i = 0; i < uuids.Count(); i++)
+	{
+		guids.push_back(ON_UUID_to_Binding(uuids[i]));
+	}
+
+	return guids;
+}
 
 #endif
 

--- a/src/bindings/bnd_uuid.h
+++ b/src/bindings/bnd_uuid.h
@@ -4,6 +4,10 @@
 
 #if defined(ON_PYTHON_COMPILE)
 typedef pybind11::object BND_UUID;
+
+PYBIND11_MAKE_OPAQUE(std::vector<BND_UUID>); //bind std::vector<BND_UUID> as opaque stl container to pass to pybind by reference
+std::vector<BND_UUID> ON_SimpleArrayUUID_to_Binding(const ON_SimpleArray<ON_UUID>& uuids);
+
 #else
 typedef std::string BND_UUID;
 #endif


### PR DESCRIPTION
Fixes #126 / RH3DM-55

It is currently not possible to read the Name, Id or the child objects of an InstanceDefinition from the .3dm file. The PR exposes the necessary variables and adds two functions to do so.

*exposes BND_InstanceDefinitionGeometry.Name and .Id

*implements BND_InstanceDefinitionGeometry.GetObjectIds() to return a std::vector<BND_UUID> containing the IDs of all child objects, that can be passed on by pybind

*to do so, the PR adds a converter to bnd_uuid.h/cpp that converts from ON_SimpleArray<ON_UUID> to std::vector<BND_UUID>


