### PR TITLE
implements BND_Transform.ToFloatArray()

### DIFF
--- a/src/bindings/bnd_xform.cpp
+++ b/src/bindings/bnd_xform.cpp
@@ -46,6 +46,26 @@ BND_Transform BND_Transform::Transpose() const
   return rc;
 }
 
+BND_TUPLE BND_Transform::ToFloatArray(bool rowDominant)
+{
+#if defined(ON_PYTHON_COMPILE)
+	int count = 16;
+	pybind11::tuple rc(count);
+	if (rowDominant)
+	{
+		for (int i = 0; i < count; i++)
+			rc[i] = m_xform.m_xform[(i - i % 4) / 4][i % 4];
+	}
+	else
+	{
+		for (int i = 0; i < count; i++)
+			rc[i] = m_xform.m_xform[i % 4][(i - i % 4) / 4];
+	}
+#else
+
+#endif	
+	return rc;
+}
 
 #if defined(ON_PYTHON_COMPILE)
 namespace py = pybind11;
@@ -69,6 +89,7 @@ void initXformBindings(pybind11::module& m)
     .def("TryGetInverse", &BND_Transform::TryGetInverse)
     .def("TransformBoundingBox", &BND_Transform::TransformBoundingBox, py::arg("bbox"))
     .def("Transpose", &BND_Transform::Transpose)
+	.def("ToFloatArray", &BND_Transform::ToFloatArray)
     ;
 }
 #endif

--- a/src/bindings/bnd_xform.h
+++ b/src/bindings/bnd_xform.h
@@ -59,5 +59,5 @@ public:
   BND_Transform* TryGetInverse() const;
   BND_Transform Transpose() const;
   //public float[] ToFloatArray(bool rowDominant)
-
+  BND_TUPLE BND_Transform::ToFloatArray(bool rowDominant);
 };


### PR DESCRIPTION
Adresses #128 / RH3DM-56

changed from previous pull request to return flat BND_TUPLE containing the transformation matrix in either row- or column major order.