### PR TITLE
Update Python CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,18 +55,17 @@ jobs:
       - run: python3 --version && cmake --version
       - run: python3 setup.py bdist_wheel
 
-  build_py2_mac:
+  build_py3_mac:
     macos:
-      xcode: "10.2.0"
+      xcode: "11.2.0"
     steps:
       # brew update required to workaround Homebrew/brew#5513
       - run: brew update
       - run: brew install cmake
-      - run: cmake --version
-      - run: python --version
       - checkout
       - run: git submodule update --init
-      - run: python setup.py bdist_wheel
+      - run: python3 --version && cmake --version
+      - run: python3 setup.py bdist_wheel
 
   build_dotnet:
     docker:
@@ -74,13 +73,8 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: python3 --version
-      - run: cmake --version
-      - run:
-          name: Build
-          command: |
-            cd src
-            python3 build_dotnet.py
+      - run: python3 --version && cmake --version && dotnet --version
+      - run: cd src && python3 build_dotnet.py
 
   build_dotnet_amazonlinux2:
     docker:
@@ -88,6 +82,7 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
+      - run: python3 --version && cmake --version && dotnet --version
       - run: cd src && python3 build_dotnet.py
 
 workflows:
@@ -100,6 +95,6 @@ workflows:
             - build_js
       - build_py2
       - build_py3
-      - build_py2_mac
+      - build_py3_mac
       - build_dotnet
       - build_dotnet_amazonlinux2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,9 @@ jobs:
 
   build_py3:
     docker:
-      - image: mcneel/rhino3dm-dev:latest
+      - image: python:3.8-slim-buster
     steps:
+      - run: apt update && apt install -yy git cmake gcc g++
       - checkout
       - run: git submodule update --init
       - run: python3 --version && cmake --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,16 @@ version: '{build}'
 
 environment:
   matrix:
-    # For Python versions available on Appveyor, see
-    # http://www.appveyor.com/docs/installed-software#python
-    - PYTHON: "C:\\Python27"
-    # NOTE: temporarily disable other flavours because it takes too long
-    # - PYTHON: "C:\\Python27-x64"
-    # - PYTHON: "C:\\Python36"
-    # - PYTHON: "C:\\Python36-x64"
+    # for Python versions available on Appveyor, see
+    # https://www.appveyor.com/docs/windows-images-software/#python
+    # only enable one version, otherwise it takes too long!
+    - PYTHON: "C:\\Python38-x64"
 
 image: Visual Studio 2017
 
 install:
   - git submodule update --recursive --init
-  # We need wheel installed to build wheels
+  # we need wheel installed to build wheels
   - "%PYTHON%\\python.exe -m pip install wheel"
 
 build: off


### PR DESCRIPTION
Use Python 3.8 (latest) on Linux and Windows and Python 3.7 (default for Catalina) on macOS