### PR TITLE
Add JS binding for BND_Transform.ToFloatArray()

### DIFF
--- a/src/bindings/bnd_xform.cpp
+++ b/src/bindings/bnd_xform.cpp
@@ -113,6 +113,7 @@ void initXformBindings(void*)
     .function("tryGetInverse", &BND_Transform::TryGetInverse, allow_raw_pointers())
     .function("transformBoundingBox", &BND_Transform::TransformBoundingBox, allow_raw_pointers())
     .function("transpose", &BND_Transform::Transpose)
+    .function("toFloatArray", &BND_Transform::ToFloatArray)
     ;
 }
 #endif


### PR DESCRIPTION
BND_Transform.ToFloatArray() was implemented by https://github.com/mcneel/rhino3dm/commit/fb1f27e20c6a55925214bfca69f17d290f554eb5 for Python but not for JavaScript.

Resolves #159 