### PR TITLE
exposes ON_3dmView.m_named_view_id

### DIFF
--- a/src/bindings/bnd_3dm_settings.cpp
+++ b/src/bindings/bnd_3dm_settings.cpp
@@ -72,6 +72,7 @@ void init3dmSettingsBindings(pybind11::module& m)
     .def_property("FocalBlurJitter", &BND_ViewInfo::GetFocalBlurJitter, &BND_ViewInfo::SetFocalBlurJitter)
     .def_property("FocalBlurSampleCount", &BND_ViewInfo::GetFocalBlurSampleCount, &BND_ViewInfo::SetFocalBlurSampleCount)
     .def_property("Viewport", &BND_ViewInfo::GetViewport, &BND_ViewInfo::SetViewport)
+	.def_property_readonly("NamedViewId", &BND_ViewInfo::NamedViewId)
     ;
 
   py::class_<BND_RenderSettings, BND_CommonObject>(m, "RenderSettings")

--- a/src/bindings/bnd_3dm_settings.h
+++ b/src/bindings/bnd_3dm_settings.h
@@ -53,6 +53,7 @@ public:
   //public ViewInfoFocalBlurModes FocalBlurMode
   class BND_Viewport* GetViewport() const;
   void SetViewport(const class BND_Viewport& viewport);
+  BND_UUID NamedViewId() const { return ON_UUID_to_Binding(m_view.m_named_view_id); }
 };
 
 class BND_RenderSettings : public BND_CommonObject


### PR DESCRIPTION
Exposes readonly property NamedViewId in python bindings to return the underlying opennurbs view id. 

Needed to address the following:
https://github.com/jesterKing/import_3dm/issues/57
