### PR TITLE
Fix setup.py for pip install -e . command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.so
 *.dylib
 *.dll
+*.pyd
 
 # Fortran module files
 *.mod
@@ -30,6 +31,9 @@
 *.exe
 *.out
 *.app
+
+# Python cache
+__pycache__/
 
 .vscode
 

--- a/docs/python/RHINO3DM-BUILD.PY.md
+++ b/docs/python/RHINO3DM-BUILD.PY.md
@@ -27,6 +27,10 @@ CMake 3.12.1 is the minimum required CMake version.
 
 * (Windows) If you are on Windows, you can create a Visual Studio project file for editing and compiling code by running the `build_python_project.py` script in the `src` directory. This is the easiest way to add new code to the project.
 
+## Compile and install a development version
+
+* (All platforms) Alternatively, running `pip install -e .` from the root of the repository will compile the Python extension, copy it in `/src/rhino3dm`, and link `/src/rhino3dm` in your installed packages. Rebuilds will be faster than building a binary distribution. To rebuild after modifying the C++ source files, run `python setup.py develop`.
+
 ## Test
 
 * `cd build_{pyver}/stage` and start `python`

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ class CMakeBuild(build_ext):
         for ext in self.extensions:
             self.build_extension(ext)
 
+        if self.inplace:
+            self.copy_extensions_to_source()
+
     def build_extension(self, ext):
         extdir = os.path.abspath(
             os.path.dirname(self.get_ext_fullpath(ext.name)))
@@ -96,6 +99,8 @@ class CMakeBuild(build_ext):
             system("make")
 
         os.chdir(current_dir)
+        if not os.path.exists(self.build_lib + "/rhino3dm"):
+            os.makedirs(self.build_lib + "/rhino3dm")
         for file in glob.glob(self.build_temp + "/Release/*.pyd"):
             shutil.copy(file, self.build_lib + "/rhino3dm")
         for file in glob.glob(self.build_temp + "/*.so"):
@@ -141,7 +146,7 @@ for obj in model.Objects:
     long_description_content_type="text/markdown",
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    ext_modules=[CMakeExtension('rhino3dm/_rhino3dm')],
+    ext_modules=[CMakeExtension('rhino3dm._rhino3dm')],
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
     include_package_data=True

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
 """# rhino3dm.py
 CPython package based on OpenNURBS with a RhinoCommon style
 
-Project Hompage at: https://github.com/mcneel/rhino3dm
+Project Homepage at: https://github.com/mcneel/rhino3dm
 
 ### Supported platforms
 * Python27 - Windows (32 and 64 bit)


### PR DESCRIPTION
This PR makes `pip install -e .` work. This way, it's possible to install an editable version of the package (ie. a link to the `/src/rhino3dm` folder in the installed packages of the current python), and changes to the python source will be picked up immediately.

Changes to the C++ source are seen after a rebuild (`python setup.py develop`); that rebuild is faster than building a binary distribution because it does not use a new temporary build folder each time (it builds in /build/temp.system).