### PR TITLE
Add bindings to access knots and CVs of a surface, and improve Python bindings for curves knots and CVs

### DIFF
--- a/src/bindings/bnd_nurbscurve.cpp
+++ b/src/bindings/bnd_nurbscurve.cpp
@@ -1,6 +1,5 @@
 #include <vector>
 #include "bindings.h"
-#include "pybind11/stl.h"
 
 BND_NurbsCurvePointList::BND_NurbsCurvePointList(ON_NurbsCurve* nurbscurve, const ON_ModelComponentReference& compref)
 {

--- a/src/bindings/bnd_nurbscurve.h
+++ b/src/bindings/bnd_nurbscurve.h
@@ -1,3 +1,4 @@
+#include <vector>
 #include "bindings.h"
 
 #pragma once
@@ -40,9 +41,10 @@ class BND_NurbsCurveKnotList
   ON_NurbsCurve* m_nurbs_curve = nullptr;
 public:
   BND_NurbsCurveKnotList(ON_NurbsCurve* nurbscurve, const ON_ModelComponentReference& compref);
+  std::vector<double> ToList();
   int Count() const { return m_nurbs_curve->KnotCount(); }
-  double GetKnot(int index) const { return m_nurbs_curve->Knot(index); }
-  void SetKnot(int index, double k) { m_nurbs_curve->SetKnot(index, k); }
+  double GetKnot(int index) const;
+  void SetKnot(int index, double k);
   bool InsertKnot(double value, int multiplicity) { return m_nurbs_curve->InsertKnot(value, multiplicity); }
   int KnotMultiplicity(int index) const { return m_nurbs_curve->KnotMultiplicity(index); }
   bool CreateUniformKnots(double knotSpacing) { return m_nurbs_curve->MakeClampedUniformKnotVector(knotSpacing); }

--- a/src/bindings/bnd_nurbscurve.h
+++ b/src/bindings/bnd_nurbscurve.h
@@ -15,6 +15,8 @@ class BND_NurbsCurvePointList
   ON_NurbsCurve* m_nurbs_curve = nullptr;
 public:
   BND_NurbsCurvePointList(ON_NurbsCurve* nurbscurve, const ON_ModelComponentReference& compref);
+  ON_NurbsCurve* GetCurve() { return m_nurbs_curve; }
+  int GetCVDims() { return m_nurbs_curve->m_is_rat ? m_nurbs_curve->m_dim + 1 : m_nurbs_curve->m_dim; }
   int Count() const { return m_nurbs_curve->CVCount(); }
   ON_4dPoint GetControlPoint(int index) const;
   void SetControlPoint(int index, ON_4dPoint point);
@@ -42,6 +44,7 @@ class BND_NurbsCurveKnotList
 public:
   BND_NurbsCurveKnotList(ON_NurbsCurve* nurbscurve, const ON_ModelComponentReference& compref);
   std::vector<double> ToList();
+  ON_NurbsCurve* GetCurve() { return m_nurbs_curve; }
   int Count() const { return m_nurbs_curve->KnotCount(); }
   double GetKnot(int index) const;
   void SetKnot(int index, double k);

--- a/src/bindings/bnd_nurbssurface.cpp
+++ b/src/bindings/bnd_nurbssurface.cpp
@@ -1,6 +1,5 @@
 #include <vector>
 #include "bindings.h"
-#include "pybind11/stl.h"
 
 BND_NurbsSurfacePointList::BND_NurbsSurfacePointList(ON_NurbsSurface* surface, const ON_ModelComponentReference& compref)
 {
@@ -267,11 +266,11 @@ void initNurbsSurfaceBindings(void*)
     .function("makeNonRational", &BND_NurbsSurface::MakeNonRational)
     .function("increaseDegreeU", &BND_NurbsSurface::IncreaseDegreeU)
     .function("increaseDegreeV", &BND_NurbsSurface::IncreaseDegreeV)
-    .property("orderU", &BND_NurbsSurface::OrderU)
-    .property("orderV", &BND_NurbsSurface::OrderV)
-    .property("knotsU", &BND_NurbsSurface::KnotsU)
-    .property("knotsV", &BND_NurbsSurface::KnotsV)
-    .property("points", &BND_NurbsSurface::Points)
+    //.property("orderU", &BND_NurbsSurface::OrderU)
+    //.property("orderV", &BND_NurbsSurface::OrderV)
+    //.property("knotsU", &BND_NurbsSurface::KnotsU)
+    //.property("knotsV", &BND_NurbsSurface::KnotsV)
+    //.property("points", &BND_NurbsSurface::Points)
     ;
 }
 #endif

--- a/src/bindings/bnd_nurbssurface.h
+++ b/src/bindings/bnd_nurbssurface.h
@@ -8,6 +8,53 @@ void initNurbsSurfaceBindings(pybind11::module& m);
 void initNurbsSurfaceBindings(void* m);
 #endif
 
+class BND_NurbsSurfacePointList
+{
+  ON_ModelComponentReference m_component_reference;
+  ON_NurbsSurface* m_surface = nullptr;
+  int m_direction;
+public:
+  BND_NurbsSurfacePointList(ON_NurbsSurface* nurbscurve, const ON_ModelComponentReference& compref);
+  int CountU() const { return m_surface->CVCount(0); }
+  int CountV() const { return m_surface->CVCount(1); }
+  int Count() const { return CountU() * CountV(); }
+  ON_4dPoint GetControlPoint(int indexU, int indexV) const;
+  void SetControlPoint(int indexU, int indexV, ON_4dPoint point);
+  //class BND_Polyline* ControlPolygon() const;
+  bool MakeRational() { return m_surface->MakeRational(); }
+  bool MakeNonRational() { return m_surface->MakeNonRational(); }
+  //public bool SetPoint(int index, double x, double y, double z)
+  //public bool SetPoint(int index, double x, double y, double z, double weight)
+  //public bool SetPoint(int index, Point3d point)
+  //public bool SetPoint(int index, Point4d point)
+  //public bool SetPoint(int index, Point3d point, double weight)
+  //public bool GetPoint(int index, out Point3d point)
+  //public bool GetPoint(int index, out Point4d point)
+  //public bool SetWeight(int index, double weight)
+  //public double GetWeight(int index)
+  //public int PointSize{ get; }
+};
+
+class BND_NurbsSurfaceKnotList
+{
+  ON_ModelComponentReference m_component_reference;
+  ON_NurbsSurface* m_surface = nullptr;
+  int m_direction;
+public:
+  BND_NurbsSurfaceKnotList(ON_NurbsSurface* nurbscurve, int direction, const ON_ModelComponentReference& compref);
+  int Count() const { return m_surface->KnotCount(m_direction); }
+  double GetKnot(int index) const { return m_surface->Knot(m_direction, index); }
+  void SetKnot(int index, double k) { m_surface->SetKnot(m_direction, index, k); }
+  bool InsertKnot(double value, int multiplicity) { return m_surface->InsertKnot(m_direction, value, multiplicity); }
+  int KnotMultiplicity(int index) const { return m_surface->KnotMultiplicity(m_direction, index); }
+  bool CreateUniformKnots(double knotSpacing) { return m_surface->MakeClampedUniformKnotVector(m_direction, knotSpacing); }
+  bool CreatePeriodicKnots(double knotSpacing) { return m_surface->MakePeriodicUniformKnotVector(m_direction, knotSpacing); }
+  bool IsClampedStart() const { return m_surface->IsClamped(m_direction, 0); }
+  bool IsClampedEnd() const { return m_surface->IsClamped(m_direction, 1); }
+  //public bool ClampEnd(CurveEnd end)
+  double SuperfluousKnot(bool start) const { return m_surface->SuperfluousKnot(m_direction, start ? 0 : 1); }
+};
+
 class BND_NurbsSurface : public BND_Surface
 {
   ON_NurbsSurface* m_nurbssurface = nullptr;
@@ -31,6 +78,9 @@ public:
   //public bool EpsilonEquals(NurbsSurface other, double epsilon)
   int OrderU() const { return m_nurbssurface->Order(0); }
   int OrderV() const { return m_nurbssurface->Order(1); }
+  BND_NurbsSurfaceKnotList KnotsU();
+  BND_NurbsSurfaceKnotList KnotsV();
+  BND_NurbsSurfacePointList Points();
 
 protected:
   void SetTrackedPointer(ON_NurbsSurface* nurbssurface, const ON_ModelComponentReference* compref);

--- a/src/bindings/bnd_nurbssurface.h
+++ b/src/bindings/bnd_nurbssurface.h
@@ -16,6 +16,8 @@ class BND_NurbsSurfacePointList
   int m_direction;
 public:
   BND_NurbsSurfacePointList(ON_NurbsSurface* nurbscurve, const ON_ModelComponentReference& compref);
+  ON_NurbsSurface* GetSurface() { return m_surface; }
+  int GetCVDims() { return m_surface->m_is_rat ? m_surface->m_dim + 1 : m_surface->m_dim; }
   int CountU() const { return m_surface->CVCount(0); }
   int CountV() const { return m_surface->CVCount(1); }
   int Count() const { return CountU() * CountV(); }
@@ -44,6 +46,8 @@ class BND_NurbsSurfaceKnotList
 public:
   BND_NurbsSurfaceKnotList(ON_NurbsSurface* nurbscurve, int direction, const ON_ModelComponentReference& compref);
   std::vector<double> ToList();
+  ON_NurbsSurface* GetSurface() { return m_surface; }
+  int GetDirection() { return m_direction; }
   int Count() const { return m_surface->KnotCount(m_direction); }
   double GetKnot(int index) const;
   void SetKnot(int index, double k);

--- a/src/bindings/bnd_nurbssurface.h
+++ b/src/bindings/bnd_nurbssurface.h
@@ -1,3 +1,4 @@
+#include <vector>
 #include "bindings.h"
 
 #pragma once
@@ -18,8 +19,8 @@ public:
   int CountU() const { return m_surface->CVCount(0); }
   int CountV() const { return m_surface->CVCount(1); }
   int Count() const { return CountU() * CountV(); }
-  ON_4dPoint GetControlPoint(int indexU, int indexV) const;
-  void SetControlPoint(int indexU, int indexV, ON_4dPoint point);
+  ON_4dPoint GetControlPoint(std::tuple<int, int> index) const;
+  void SetControlPoint(std::tuple<int, int> index, ON_4dPoint point);
   //class BND_Polyline* ControlPolygon() const;
   bool MakeRational() { return m_surface->MakeRational(); }
   bool MakeNonRational() { return m_surface->MakeNonRational(); }
@@ -42,9 +43,10 @@ class BND_NurbsSurfaceKnotList
   int m_direction;
 public:
   BND_NurbsSurfaceKnotList(ON_NurbsSurface* nurbscurve, int direction, const ON_ModelComponentReference& compref);
+  std::vector<double> ToList();
   int Count() const { return m_surface->KnotCount(m_direction); }
-  double GetKnot(int index) const { return m_surface->Knot(m_direction, index); }
-  void SetKnot(int index, double k) { m_surface->SetKnot(m_direction, index, k); }
+  double GetKnot(int index) const;
+  void SetKnot(int index, double k);
   bool InsertKnot(double value, int multiplicity) { return m_surface->InsertKnot(m_direction, value, multiplicity); }
   int KnotMultiplicity(int index) const { return m_surface->KnotMultiplicity(m_direction, index); }
   bool CreateUniformKnots(double knotSpacing) { return m_surface->MakeClampedUniformKnotVector(m_direction, knotSpacing); }


### PR DESCRIPTION
This PR has a couple related things in it about knots and CVs for curves and surfaces, and works on Python but not on WASM. Let me know if there is something to do to have the same features on both platforms and I'll correct as needed.

1. For surfaces, add bindings to get and set the knots and CVs. These are modeled on the curve bindings, but but since the CV list is 2-dimensional for a surface, the getter/setter accepts a tuple of indices that works nicely through pybind: `srf.Points[1,2]`. Not sure how to make this work in WASM.
2. For curves and surfaces, add bounds checking to knots and CVs g/setters. This makes the collections proper iterables in Python, and things like `for k in srf.KnotsU:` work (without the bounds checking, that crashes Python). Maybe there should be a way to get/set without bounds checking? Again, don't know how this should work in WASM.
3. For curves and surfaces knots and CVs in pybind, add a `buffer_info` method. That makes the conversion to a Numpy array fast and easy: `np.asarray(srf.Points)` for example. Unless there is a Numpy equivalent in WASM, not sure this is needed there.