### PR TITLE
Javascript build support

### DIFF
--- a/docs/javascript/RHINO3DM-BUILD.JS.md
+++ b/docs/javascript/RHINO3DM-BUILD.JS.md
@@ -7,7 +7,7 @@ If the pre-compiled libraries above do not work in your situation, you can compi
 git submodule update --init
 ```
 
-### Required Tools
+## Required Tools
 
 Compiling *rhino3dm.js* can be done on macOS, Linux and Windows (via [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)). The following tools are required...
 
@@ -15,30 +15,45 @@ Compiling *rhino3dm.js* can be done on macOS, Linux and Windows (via [Windows Su
 * [Emscripten](https://emscripten.org/) - See Emscripten's [Getting started guide](https://emscripten.org/docs/getting_started/downloads.html#platform-notes-installation-instructions-sdk) or WebAssembly's [Developer's Guide](https://webassembly.org/getting-started/developers-guide/) .
 * [CMake](https://cmake.org/) (>3.12.2) - _**Note:** The version of CMake distributed with Ubuntu 18.04 LTS isn't new enough so you'll have to [build it from source](https://cmake.org/install/). This may also be true for other package managers._
 
-### bootstrap
+## Scripts
+
+A number of scripts are used to setup and build rhino3dm:
+
+- *script/bootstrap.py* - checks for (and downloads) the required tools
+- *script/setup.py* - generates the platform-specific project files using CMake
+- *script/cibuild.py* - builds the library project(s)
+
+### bootstrap.py
 
 The `script/bootstrap.py` script can be used to check your system for (and, in some cases, download) the necessary tools for a specific build target.  For example, you can run:
 
 ```bash
-$ python bootstrap.py --platform js
+$ python3 bootstrap.py --platform js
 ```
 
 to check for all the tools needed to build the javascript version of rhino3dm.
 
 `bootstrap.py` supports Python 2 and 3 and can be run from Windows, macOS, or Linux.
 
-### Compile
+### setup.py
 
-After installation, make sure you have `emcmake`, `make`, and `python` on your path. Emscripten provides instructions for [adding the Emscripten tools to your PATH after install](https://emscripten.org/docs/getting_started/downloads.html#installation-instructions).
+The _setup.py_ script uses CMake to generate the make files necessary to build the project.  These projects are generated into _build/javascript_ folder.  To setup a JavaScript build, you can run:
 
 ```bash
-$ cd src
-$ python build_javascript.py
+$ python3 setup.py --platform js
 ```
 
-The build might take a few minutes, but if everything is configured correctly you should now have `rhino3dm.js`, `rhino3dm.wasm` and several samples in the `src/build/artifacts_js` directory.
+### build.py
 
-### Test
+The _build.py_ script run `make` to build the _rhino3dm.js_ and _rhino3dm.wasm_ files to the _build/javascript/artifacts\_js_ folder.  To build, run:
+
+```bash
+$ python3 build.py --platform js --overwrite
+```
+
+The build might take a few minutes, but if everything is configured correctly you should now have _rhino3dm.js_ and _rhino3dm.wasm_ in the _build/javascript/artifacts\_js_ folder.  The script also copies these files to the _docs/javascript/samples/resources_ folder where they can be used for testing.  
+
+## Test
 
 * `cd` to the `docs/javascript/samples` folder.
 
@@ -46,12 +61,13 @@ The build might take a few minutes, but if everything is configured correctly yo
 
 * Go to your browser and navigate to `http://localhost:8080/rhino3dm.html`
 
-* For chrome, right click and select `inspect`. Click on the `console` tab and try typing in the following javascript
-  ```js
-  > sphere = new _rhino3dm.Sphere([1,2,3], 12);
-  > brep = sphere.toBrep();
-  > jsonobject = brep.encode();
-  ```
+* For chrome, right click and select `inspect`. Click on the `console` tab and try typing in the following javascript:
+  
+```js
+> sphere = new _rhino3dm.Sphere([1,2,3], 12);
+> brep = sphere.toBrep();
+> jsonobject = brep.encode();
+```
 
 ## Related Topics
 

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -521,7 +521,7 @@ def main():
 
     # cli metadata
     description = "check for and download developer tools for rhino3dm for a specified platform."
-    epilog = ""
+    epilog = "supported platforms and tools: " + ", ".join(valid_platform_args) + ", " + ", ".join(build_tools)
 
     # Parse arguments
     parser = argparse.ArgumentParser(description=description, epilog=epilog)

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -30,7 +30,6 @@ from sys import platform as _platform
 
 xcode_logging = False
 valid_platform_args = ["js"]
-# TODO: "android", "ios", "dotnet", "linux", "macos", "python", "windows"
 
 
 class BuildTool:
@@ -43,7 +42,6 @@ class BuildTool:
 
 
 # ---------------------------------------------------- Logging ---------------------------------------------------------
-
 # colors for terminal reporting
 class bcolors:
     HEADER = '\033[95m'

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -10,7 +10,8 @@
 from __future__ import (division, absolute_import, print_function, unicode_literals)
 
 import subprocess
-import sys, os, tempfile, logging
+import sys
+import os
 import argparse
 import ssl
 import platform
@@ -511,6 +512,7 @@ def download_handler(download, build_tools):
                 download_dependency(build_tools[tool])
         else:
             download_dependency(build_tools[download])
+
 
 # --------------------------------------------------- Main -------------------------------------------------------------
 def main():

--- a/script/build.py
+++ b/script/build.py
@@ -8,11 +8,17 @@
 #
 # This script uses the "Scripts To Rule Them All" pattern: https://github.com/github/scripts-to-rule-them-all
 
+from __future__ import (division, absolute_import, print_function, unicode_literals)
+
 import subprocess
 import sys
 import os
 import argparse
 import platform
+from sys import platform as _platform
+import shlex
+import shutil
+from subprocess import Popen, PIPE
 
 # ---------------------------------------------------- Globals ---------------------------------------------------------
 
@@ -20,11 +26,12 @@ xcode_logging = False
 verbose = False
 overwrite = False
 valid_platform_args = ["js"]
-# TODO: "android", "ios", "dotnet", "linux", "macos", "python", "windows"
-
+platform_full_names = {'js': 'JavaScript', 'ios': 'iOS'}
+script_folder = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+build_folder = os.path.abspath(os.path.join(script_folder, "..", "build"))
+docs_folder = os.path.abspath(os.path.join(script_folder, "..", "docs"))
 
 # ---------------------------------------------------- Logging ---------------------------------------------------------
-
 # colors for terminal reporting
 class bcolors:
     HEADER = '\033[95m'
@@ -62,6 +69,112 @@ def print_ok_message(ok_message):
     else:
         print(bcolors.BOLD + bcolors.OKBLUE + ok_prefix.upper() + bcolors.ENDC + bcolors.OKBLUE + ok_message +
               bcolors.ENDC)
+
+
+# ---------------------------------------------- Platform Build --------------------------------------------------------
+def print_platform_preamble(platform_target_name):
+    print("")
+    if xcode_logging:
+        print("Building " + platform_target_name + "...")
+    else:
+        print(bcolors.BOLD + "Building " + platform_target_name + "..." + bcolors.ENDC)
+
+
+def run_command_show_output(command):
+    if verbose:
+        process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE)
+    else:
+        dev_null = open(os.devnull, 'w')  # sending to dev/null here because sending everything to pipe causes hang
+        process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=dev_null)
+    while True:
+        output = process.stdout.readline()
+        if not output:
+            break
+        if len(output) == 0 and process.poll() is not None:
+            break
+        if output:
+            if sys.version_info[0] < 3:
+                print(output.strip())
+            else:
+                output = output.decode('utf-8').strip()
+                print(output)
+
+    rc = process.poll()
+    return rc
+
+
+def build_js():
+    platform_target_path = os.path.join(build_folder, platform_full_names.get("js").lower())
+
+    previous_build = os.path.abspath(os.path.join(platform_target_path, "artifacts_js"))
+    if os.path.exists(previous_build):
+        if not overwrite:
+            print_warning_message("build already appears in " + previous_build + ". Use --overwrite to replace.")
+            return False
+        if overwrite:
+            shutil.rmtree(previous_build)
+
+    item_to_check = os.path.abspath(os.path.join(platform_target_path, "CMakeFiles"))
+    if not os.path.exists(item_to_check):
+        print_error_message("CMakeFiles not found in " + item_to_check + ". Did you run setup.py?")
+        return False
+
+    os.chdir(platform_target_path)
+
+    if overwrite:
+        try:
+            subprocess.Popen(['make', 'clean'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        except OSError:
+            print_error_message("unable to run make clean in " + platform_target_path)
+            return False
+
+    run_command_show_output("make")
+
+    # Check to see if the build succeeded and move into artifacts_js
+    items_to_check = ['rhino3dm.wasm', 'rhino3dm.js']
+    all_items_built = True
+    for item in items_to_check:
+        path_to_item = os.path.abspath(os.path.join(platform_target_path, item))
+        if not os.path.exists(path_to_item):
+            print_error_message("failed to create " + path_to_item)
+            all_items_built = False
+        else:
+            artifacts_folder_path = os.path.abspath(os.path.join(platform_target_path, "artifacts_js"))
+            if not os.path.exists(artifacts_folder_path):
+                os.mkdir(artifacts_folder_path)
+            shutil.move(path_to_item, os.path.abspath(os.path.join(artifacts_folder_path, item)))
+
+    if all_items_built:
+        print_ok_message("built target rhino3dm succeeded. see: " + artifacts_folder_path)
+    else:
+        print_error_message("failed to build all rhino3dm build artifacts.")
+        return False
+
+    # Copy artifacts into samples folder
+    for item in items_to_check:
+        artifacts_folder_path = os.path.abspath(os.path.join(platform_target_path, "artifacts_js"))
+        path_to_item = os.path.abspath(os.path.join(artifacts_folder_path, item))
+        if os.path.exists(path_to_item):
+            resources_path = os.path.abspath(os.path.join(docs_folder, platform_full_names.get("js").lower(),
+                                                          "samples", "resources"))
+            destination_path = os.path.abspath(os.path.join(resources_path, item))
+            shutil.copyfile(path_to_item, destination_path)
+            if os.path.exists(destination_path):
+                print_ok_message("copied " + item + " to: " + destination_path)
+
+    os.chdir(script_folder)
+
+
+def build_handler(platform_target):
+    if platform_target == "all":
+        for target in valid_platform_args:
+            print_platform_preamble(platform_full_names.get(target))
+            getattr(sys.modules[__name__], 'build_' + target)()
+    else:
+        print_platform_preamble(platform_full_names.get(platform_target))
+        getattr(sys.modules[__name__], 'build_' + platform_target)()
+
+    os.chdir(script_folder)
 
 
 # --------------------------------------------------- Main -------------------------------------------------------------
@@ -102,7 +215,14 @@ def main():
     global overwrite
     overwrite = args.overwrite
 
-    # TODO: Process platform, etc.
+    # build platform(s)
+    if args.platform is not None:
+        for platform_target in args.platform:
+            if (platform_target != "all") and (platform_target not in valid_platform_args):
+                print_error_message(platform_target + " is not a valid platform argument. valid tool arguments: all, "
+                                    + ", ".join(valid_platform_args) + ".")
+                sys.exit(1)
+            build_handler(platform_target)
 
 
 if __name__ == "__main__":

--- a/script/build.py
+++ b/script/build.py
@@ -1,4 +1,4 @@
-# cibuild.py
+# build.py
 # created: January 15, 2020
 #
 # This script builds the native library for rhino3dm for the platforms that we target. It requires that the setup

--- a/script/cibuild.py
+++ b/script/cibuild.py
@@ -1,0 +1,109 @@
+# cibuild.py
+# created: January 15, 2020
+#
+# This script builds the native library for rhino3dm for the platforms that we target. It requires that the setup
+# script has previously been run in order to generate the project files for the the specific platform(s).
+# See bootstrap script for required tools.  This script cannot be moved from its current location without
+# reworking the relative paths that point to the build locations of the platform project files.
+#
+# This script uses the "Scripts To Rule Them All" pattern: https://github.com/github/scripts-to-rule-them-all
+
+import subprocess
+import sys
+import os
+import argparse
+import platform
+
+# ---------------------------------------------------- Globals ---------------------------------------------------------
+
+xcode_logging = False
+verbose = False
+overwrite = False
+valid_platform_args = ["js"]
+# TODO: "android", "ios", "dotnet", "linux", "macos", "python", "windows"
+
+
+# ---------------------------------------------------- Logging ---------------------------------------------------------
+
+# colors for terminal reporting
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+def print_warning_message(warning_message):
+    warning_prefix = " warning: "
+    if xcode_logging:
+        print(warning_prefix + warning_message)
+    else:
+        print(bcolors.BOLD + bcolors.FAIL + warning_prefix.upper() + bcolors.ENDC + bcolors.FAIL + warning_message +
+              bcolors.ENDC)
+
+
+def print_error_message(error_message):
+    error_prefix = " error: "
+    if xcode_logging:
+        print(error_prefix + error_message)
+    else:
+        print(bcolors.BOLD + bcolors.FAIL + error_prefix.upper() + bcolors.ENDC + bcolors.FAIL + error_message +
+              bcolors.ENDC)
+
+
+def print_ok_message(ok_message):
+    ok_prefix = " ok: "
+    if xcode_logging:
+        print(ok_prefix + ok_message)
+    else:
+        print(bcolors.BOLD + bcolors.OKBLUE + ok_prefix.upper() + bcolors.ENDC + bcolors.OKBLUE + ok_message +
+              bcolors.ENDC)
+
+
+# --------------------------------------------------- Main -------------------------------------------------------------
+def main():
+    global valid_platform_args
+
+    # cli metadata
+    description = "builds the native libraries for rhino3dm"
+    epilog = ""
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(description=description, epilog=epilog)
+    parser.add_argument('--platform', '-p', metavar='<platform>', nargs='+',
+                        help="build the native library for the platform(s) specified. valid arguments: all, "
+                             + ", ".join(valid_platform_args) + ".")
+    parser.add_argument('--overwrite', '-o', action='store_true',
+                        help="overwrite existing builds (if found)")
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help="show verbose logging messages")
+    parser.add_argument('--xcodelog', '-x', action='store_true',
+                        help="generate Xcode-compatible log messages (no colors or other Terminal-friendly gimmicks)")
+    args = parser.parse_args()
+
+    # User has not entered any arguments...
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    global xcode_logging
+    xcode_logging = args.xcodelog
+
+    if _platform == "win32":
+        xcode_logging = True
+
+    global verbose
+    verbose = args.verbose
+
+    global overwrite
+    overwrite = args.overwrite
+
+    # TODO: Process platform, etc.
+
+
+if __name__ == "__main__":
+    main()

--- a/script/setup.py
+++ b/script/setup.py
@@ -71,7 +71,7 @@ def main():
     # Parse arguments
     parser = argparse.ArgumentParser(description=description, epilog=epilog)
     parser.add_argument('--platform', '-p', metavar='<platform>', nargs='+',
-                        help="generates the project files for the  platform(s) specified. valid arguments: all, "
+                        help="generates the project files for the platform(s) specified. valid arguments: all, "
                              + ", ".join(valid_platform_args) + ".")
     parser.add_argument('--verbose', '-v', action='store_true',
                         help="show verbose logging messages")

--- a/script/setup.py
+++ b/script/setup.py
@@ -22,7 +22,7 @@ overwrite = False
 valid_platform_args = ["js"]
 platform_full_names = {'js': 'JavaScript', 'ios': 'iOS'}
 script_folder = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-build_folder = os.path.abspath(os.path.join(script_folder, "..", "src", "build"))
+build_folder = os.path.abspath(os.path.join(script_folder, "..", "build"))
 
 # ---------------------------------------------------- Logging ---------------------------------------------------------
 
@@ -90,7 +90,7 @@ def setup_js():
 
     os.chdir(platform_target_path)
 
-    command = "emcmake cmake -DCMAKE_CXX_FLAGS=\"-s MODULARIZE=1 -s 'EXPORT_NAME=\\\"rhino3dm\\\"'\" ../.."
+    command = "emcmake cmake -DCMAKE_CXX_FLAGS=\"-s MODULARIZE=1 -s 'EXPORT_NAME=\\\"rhino3dm\\\"'\" ../../src"
     try:
         p = subprocess.Popen(shlex.split(command), stdin=PIPE, stdout=PIPE, stderr=PIPE)
     except OSError:

--- a/script/setup.py
+++ b/script/setup.py
@@ -1,0 +1,102 @@
+# setup.py
+# created: January 15, 2020
+#
+# Uses the CMake (https://cmake.org) tools to generate the platform-specific rhino3dm projects
+#
+# This script uses the "Scripts To Rule Them All" pattern: https://github.com/github/scripts-to-rule-them-all
+
+import subprocess
+import sys
+import os
+import argparse
+import platform
+
+# ---------------------------------------------------- Globals ---------------------------------------------------------
+
+xcode_logging = False
+verbose = False
+valid_platform_args = ["js"]
+# TODO: "android", "ios", "dotnet", "linux", "macos", "python", "windows"
+
+
+# ---------------------------------------------------- Logging ---------------------------------------------------------
+
+# colors for terminal reporting
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+def print_warning_message(warning_message):
+    warning_prefix = " warning: "
+    if xcode_logging:
+        print(warning_prefix + warning_message)
+    else:
+        print(bcolors.BOLD + bcolors.FAIL + warning_prefix.upper() + bcolors.ENDC + bcolors.FAIL + warning_message +
+              bcolors.ENDC)
+
+
+def print_error_message(error_message):
+    error_prefix = " error: "
+    if xcode_logging:
+        print(error_prefix + error_message)
+    else:
+        print(bcolors.BOLD + bcolors.FAIL + error_prefix.upper() + bcolors.ENDC + bcolors.FAIL + error_message +
+              bcolors.ENDC)
+
+
+def print_ok_message(ok_message):
+    ok_prefix = " ok: "
+    if xcode_logging:
+        print(ok_prefix + ok_message)
+    else:
+        print(bcolors.BOLD + bcolors.OKBLUE + ok_prefix.upper() + bcolors.ENDC + bcolors.OKBLUE + ok_message +
+              bcolors.ENDC)
+
+
+# --------------------------------------------------- Main -------------------------------------------------------------
+def main():
+    global valid_platform_args
+
+    # cli metadata
+    description = "generate the project files for rhino3dm"
+    epilog = ""
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(description=description, epilog=epilog)
+    parser.add_argument('--platform', '-p', metavar='<platform>', nargs='+',
+                        help="generates the project files for the  platform(s) specified. valid arguments: all, "
+                             + ", ".join(valid_platform_args) + ".")
+    parser.add_argument('--verbose', '-v', action='store_true',
+                        help="show verbose logging messages")
+    parser.add_argument('--xcodelog', '-x', action='store_true',
+                        help="generate Xcode-compatible log messages (no colors or other Terminal-friendly gimmicks)")
+    args = parser.parse_args()
+
+    # User has not entered any arguments...
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
+    global xcode_logging
+    xcode_logging = args.xcodelog
+
+    if _platform == "win32":
+        xcode_logging = True
+
+    global verbose
+    verbose = args.verbose
+
+    # TODO: Process platform, etc.
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/script/setup.py
+++ b/script/setup.py
@@ -9,15 +9,20 @@ import subprocess
 import sys
 import os
 import argparse
-import platform
+from sys import platform as _platform
+from subprocess import Popen, PIPE
+import shlex
+import shutil
 
 # ---------------------------------------------------- Globals ---------------------------------------------------------
 
 xcode_logging = False
 verbose = False
+overwrite = False
 valid_platform_args = ["js"]
-# TODO: "android", "ios", "dotnet", "linux", "macos", "python", "windows"
-
+platform_full_names = {'js': 'JavaScript', 'ios': 'iOS'}
+script_folder = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
+build_folder = os.path.abspath(os.path.join(script_folder, "..", "src", "build"))
 
 # ---------------------------------------------------- Logging ---------------------------------------------------------
 
@@ -60,13 +65,84 @@ def print_ok_message(ok_message):
               bcolors.ENDC)
 
 
+# ---------------------------------------------- Platform Setup --------------------------------------------------------
+def print_platform_preamble(platform_target_name):
+    print("")
+    if xcode_logging:
+        print("Setting up " + platform_target_name + "...")
+    else:
+        print(bcolors.BOLD + "Setting up " + platform_target_name + "..." + bcolors.ENDC)
+
+
+def setup_js():
+    platform_target_path = os.path.join(build_folder, platform_full_names.get("js").lower())
+
+    item_to_check = os.path.abspath(os.path.join(platform_target_path, "CMakeFiles"))
+    if os.path.exists(item_to_check):
+        if not overwrite:
+            print_warning_message("CMakeFiles already appear in " + item_to_check + ". Use --overwrite to replace.")
+            return False
+        if overwrite:
+            shutil.rmtree(platform_target_path)
+
+    if not os.path.exists(platform_target_path):
+        os.mkdir(platform_target_path)
+
+    os.chdir(platform_target_path)
+
+    command = "emcmake cmake -DCMAKE_CXX_FLAGS=\"-s MODULARIZE=1 -s 'EXPORT_NAME=\\\"rhino3dm\\\"'\" ../.."
+    try:
+        p = subprocess.Popen(shlex.split(command), stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    except OSError:
+        print_error_message("could not find emcmake command.  Run the bootstrap.py --check emscripten")
+        return False
+
+    if sys.version_info[0] < 3:
+        output = p.communicate()[0]
+        if output:
+            if verbose:
+                print(output)
+        else:
+            print_error_message("failed to run emcmake cmake.")
+    else:
+        output, err = p.communicate()
+        output = output.decode('utf-8')
+        err = err.decode('utf-8')
+        if output:
+            if verbose:
+                print(output)
+        elif err:
+            print_error_message(err)
+
+    # Check to see if the CMakeFiles were written...
+    if os.path.exists(item_to_check):
+        print_ok_message("build files have been written to: " + platform_target_path)
+    else:
+        print_error_message("failed to configure and generate CMakeFiles for JavaScript build")
+
+    os.chdir(script_folder)
+
+
+def setup_handler(platform_target):
+    if not os.path.exists(build_folder):
+        os.mkdir(build_folder)
+
+    if platform_target == "all":
+        for target in valid_platform_args:
+            print_platform_preamble(platform_full_names.get(target))
+            getattr(sys.modules[__name__], 'setup_' + target)()
+    else:
+        print_platform_preamble(platform_full_names.get(platform_target))
+        getattr(sys.modules[__name__], 'setup_' + platform_target)()
+
+
 # --------------------------------------------------- Main -------------------------------------------------------------
 def main():
     global valid_platform_args
 
     # cli metadata
     description = "generate the project files for rhino3dm"
-    epilog = ""
+    epilog = "supported platforms: " + ", ".join(valid_platform_args)
 
     # Parse arguments
     parser = argparse.ArgumentParser(description=description, epilog=epilog)
@@ -75,6 +151,8 @@ def main():
                              + ", ".join(valid_platform_args) + ".")
     parser.add_argument('--verbose', '-v', action='store_true',
                         help="show verbose logging messages")
+    parser.add_argument('--overwrite', '-o', action='store_true',
+                        help="overwrite existing configurations (if found)")
     parser.add_argument('--xcodelog', '-x', action='store_true',
                         help="generate Xcode-compatible log messages (no colors or other Terminal-friendly gimmicks)")
     args = parser.parse_args()
@@ -93,7 +171,17 @@ def main():
     global verbose
     verbose = args.verbose
 
-    # TODO: Process platform, etc.
+    global overwrite
+    overwrite = args.overwrite
+
+    # setup platform(s)
+    if args.platform is not None:
+        for platform_target in args.platform:
+            if (platform_target != "all") and (platform_target not in valid_platform_args):
+                print_error_message(platform_target + " is not a valid platform argument. valid tool arguments: all, "
+                                    + ", ".join(valid_platform_args) + ".")
+                sys.exit(1)
+            setup_handler(platform_target)
 
 
 if __name__ == "__main__":

--- a/script/setup.py
+++ b/script/setup.py
@@ -24,8 +24,8 @@ platform_full_names = {'js': 'JavaScript', 'ios': 'iOS'}
 script_folder = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 build_folder = os.path.abspath(os.path.join(script_folder, "..", "build"))
 
-# ---------------------------------------------------- Logging ---------------------------------------------------------
 
+# ---------------------------------------------------- Logging ---------------------------------------------------------
 # colors for terminal reporting
 class bcolors:
     HEADER = '\033[95m'


### PR DESCRIPTION
_scripts/bootstrap.py_
_scripts/setup.py_
and
_script/build.py_

now support javascript build targets.
This reproduces - and improves upon - the _src/build_javascript.py_ which should be phased out.

Cite #183
