### PR TITLE
Parse cmake version on amazon linux 2

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -421,7 +421,7 @@ def check_cmake(build_tool):
         if err:
             print_warning_message(err)
             return
-        running_version = running_version.decode('utf-8').splitlines()[0].strip().split('cmake version ')[1]
+        running_version = re.split(r'cmake3? version ', running_version.decode('utf-8').splitlines()[0].strip())[1]
 
     print_version_comparison(build_tool, running_version)
 


### PR DESCRIPTION
On Amazon Linux 2, a useable version of cmake can be installed via `sudo yum install cmake3`. The build scripts look for `cmake` so I created a symlink to get around this. Unfortunately `cmake --version` still returns `cmake3 version 3.13.1`, hence this ~~hack~~ change.