### PR TITLE
Use Rhino3dm.core.csproj to build multi-targeting nuget package

### DIFF
--- a/src/dotnet/Properties/AssemblyInfo.cs
+++ b/src/dotnet/Properties/AssemblyInfo.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#if !DOTNETCORE
 // General Information about an assembly is controlled through the following 
+#if !DOTNETCORE && MOBILE_BUILD
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Rhino3dm")]
@@ -63,7 +63,7 @@ using System.Runtime.InteropServices;
 // 29 Aug 2017 - switch to automated assembly versioning
 
 #if RHINO3DM_BUILD
-#if !DOTNETCORE
+#if !DOTNETCORE && MOBILE_BUILD
 [assembly: AssemblyVersion("7.0.0.1")]
 #endif
 #endif

--- a/src/dotnet/Properties/AssemblyInfo.cs
+++ b/src/dotnet/Properties/AssemblyInfo.cs
@@ -2,8 +2,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
 #if !DOTNETCORE && MOBILE_BUILD
+// General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Rhino3dm")]

--- a/src/dotnet/Rhino3dm.core.csproj
+++ b/src/dotnet/Rhino3dm.core.csproj
@@ -12,20 +12,10 @@
     <!-- <Version>1.0.3</Version> -->
   </PropertyGroup>
 
-  <ItemGroup Condition="exists('..\build\windows\win32\Release\librhino3dm_native.dll')">
-    <None Include="..\build\windows\win32\Release\librhino3dm_native.dll">
-      <PackagePath>runtimes\win-x86\native</PackagePath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Win32\%(Filename)%(Extension)</Link>
-      <Pack>true</Pack>
-    </None>
-  </ItemGroup>
-
   <ItemGroup Condition="exists('..\build\windows\win64\Release\librhino3dm_native.dll')">
     <None Include="..\build\windows\win64\Release\librhino3dm_native.dll">
       <PackagePath>runtimes\win-x64\native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Win64\%(Filename)%(Extension)</Link>
       <Pack>true</Pack>
     </None>
   </ItemGroup>

--- a/src/dotnet/Rhino3dm.core.csproj
+++ b/src/dotnet/Rhino3dm.core.csproj
@@ -1,15 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <DefineConstants>$(DefineConstants);RHINO3DM_BUILD</DefineConstants>
-    <!-- TODO: replace DOTNETCORE with NETSTANDARD2_0 and remove line below -->
-    <!-- (see https://docs.microsoft.com/en-us/nuget/create-packages/multiple-target-frameworks-project-file) -->
     <DefineConstants Condition="'$(TargetFramework)'=='netstandard2.0'">$(DefineConstants);DOTNETCORE</DefineConstants>
     <AssemblyName>Rhino3dm</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Rhino</RootNamespace>
-    <!-- <Version>1.0.3</Version> -->
+    <Version>1.0.11</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="exists('..\build\windows\win64\Release\librhino3dm_native.dll')">
@@ -34,6 +32,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>true</Pack>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="build\**" Pack="True" PackagePath="build\" />
   </ItemGroup>
 
 </Project>

--- a/src/dotnet/Rhino3dm.core.csproj
+++ b/src/dotnet/Rhino3dm.core.csproj
@@ -9,6 +9,41 @@
     <AssemblyName>Rhino3dm</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Rhino</RootNamespace>
+    <!-- <Version>1.0.3</Version> -->
   </PropertyGroup>
+
+  <ItemGroup Condition="exists('..\build\windows\win32\Release\librhino3dm_native.dll')">
+    <None Include="..\build\windows\win32\Release\librhino3dm_native.dll">
+      <PackagePath>runtimes\win-x86\native</PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Win32\%(Filename)%(Extension)</Link>
+      <Pack>true</Pack>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="exists('..\build\windows\win64\Release\librhino3dm_native.dll')">
+    <None Include="..\build\windows\win64\Release\librhino3dm_native.dll">
+      <PackagePath>runtimes\win-x64\native</PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Win64\%(Filename)%(Extension)</Link>
+      <Pack>true</Pack>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="exists('..\build\macos\Release\librhino3dm_native.dylib')">
+    <None Include="..\build\macos\Release\librhino3dm_native.dylib">
+      <PackagePath>runtimes\osx-x64\native</PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="exists('..\build\linux\Release\librhino3dm_native.so')">
+    <None Include="..\build\linux\Release\librhino3dm_native.so">
+      <PackagePath>runtimes\linux-x64\native</PackagePath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/dotnet/Rhino3dm.core.csproj
+++ b/src/dotnet/Rhino3dm.core.csproj
@@ -7,7 +7,16 @@
     <AssemblyName>Rhino3dm</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Rhino</RootNamespace>
-    <Version>1.0.11</Version>
+    <Version>0.1.0</Version>
+    <PackageId>Rhino3dm</PackageId>
+    <Authors>mcneel</Authors>
+    <PackageTitle>.NET library based on OpenNURBS with a "RhinoCommon" style</PackageTitle>
+    <PackageDescription>rhino3dm is a set of libraries based on the OpenNURBS geometry library with a "RhinoCommon" style. This provides the ability to access and manipulate geometry through .NET, Python or JavaScript applications independent of Rhino.</PackageDescription>
+    <RepositoryUrl>https://github.com/mcneel/rhino3dm</RepositoryUrl>
+    <PackageTags>rhino3d</PackageTags>
+    <Copyright>Copyright (c) 1997-2020 Robert McNeel &amp; Associates</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIconUrl>https://github.com/mcneel/developer-rhino3d-com/raw/6/images/logo-rhino3dmio-128x128.png</PackageIconUrl>
   </PropertyGroup>
 
   <ItemGroup Condition="exists('..\build\windows\win64\Release\librhino3dm_native.dll')">

--- a/src/dotnet/Rhino3dm.core.csproj
+++ b/src/dotnet/Rhino3dm.core.csproj
@@ -1,10 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <DefineConstants>RHINO3DM_BUILD DOTNETCORE</DefineConstants>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <DefineConstants>$(DefineConstants);RHINO3DM_BUILD</DefineConstants>
+    <!-- TODO: replace DOTNETCORE with NETSTANDARD2_0 and remove line below -->
+    <!-- (see https://docs.microsoft.com/en-us/nuget/create-packages/multiple-target-frameworks-project-file) -->
+    <DefineConstants Condition="'$(TargetFramework)'=='netstandard2.0'">$(DefineConstants);DOTNETCORE</DefineConstants>
     <AssemblyName>Rhino3dm</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RootNamespace>Rhino</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/src/dotnet/build/net46/Rhino3dm.props
+++ b/src/dotnet/build/net46/Rhino3dm.props
@@ -1,0 +1,9 @@
+<!--
+    this file is included for .net framework projects to ensure that
+    the native libraries get copied to the build output directory
+-->
+<Project>
+  <ItemGroup>
+    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\runtimes\**\*" TargetPath="%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/src/dotnet/rhino/rhinosdkfont.cs
+++ b/src/dotnet/rhino/rhinosdkfont.cs
@@ -61,7 +61,7 @@ namespace Rhino.DocObjects
       m_managed_font = managedFont;
     }
 
-#if !MOBILE_BUILD
+#if !MOBILE_BUILD && !DOTNETCORE
     /// <since>5.0</since>
     public static string[] AvailableFontFaceNames()
     {


### PR DESCRIPTION
Make sure the native libraries are in the correct directories.

* src/build/windows/win64/Release/librhino3dm_native.dll
* src/build/linux/Release/librhino3dm_native.so
* src/build/macos/Release/librhino3dm_native.dylib

Then build the .NET library for .NET Standard 2.0 and .NET Framework 4.6.

```
msbuild src/dotnet/Rhino3dm.core.csproj -restore -t:Rebuild -p:Configuration=Release
```

Finally package it all up.

```
msbuild src/dotnet/Rhino3dm.core.csproj -restore -t:Pack -p:Configuration=Release
```