### PR TITLE
Use new scripts for linux dotnet CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,16 +74,20 @@ jobs:
       - checkout
       - run: git submodule update --init
       - run: python3 --version && cmake --version && dotnet --version
-      - run: cd src && python3 build_dotnet.py
+      - run: python3 script/bootstrap.py -p linux
+      - run: python3 script/setup.py -p linux -v
+      - run: python3 script/build.py -p linux -v
 
-  build_dotnet_amazonlinux2:
+  build_dotnet_amzn2:
     docker:
-      - image: mcneel/rhino3dm-dev-amazonlinux2:latest
+      - image: mcneel/rhino3dm-dev-amzn2:latest
     steps:
       - checkout
       - run: git submodule update --init
       - run: python3 --version && cmake --version && dotnet --version
-      - run: cd src && python3 build_dotnet.py
+      - run: python3 script/bootstrap.py -p linux
+      - run: python3 script/setup.py -p linux -v
+      - run: python3 script/build.py -p linux -v
 
 workflows:
   version: 2
@@ -97,4 +101,4 @@ workflows:
       - build_py3
       - build_py3_mac
       - build_dotnet
-      - build_dotnet_amazonlinux2
+      - build_dotnet_amzn2

--- a/script/build.py
+++ b/script/build.py
@@ -260,7 +260,7 @@ def build_linux():
     target_path = os.path.join(build_folder, platform_full_names.get("linux").lower())
     output_dir = os.path.abspath(os.path.join(target_path, "dotnet"))
 
-    command = 'dotnet build ' + csproj_path + ' /p:Configuration=Release;OutDir=' + output_dir
+    command = 'dotnet build -f netstandard2.0 ' + csproj_path + ' /p:Configuration=Release;OutDir=' + output_dir
     run_command(command)
 
     item_to_check = os.path.abspath(os.path.join(output_dir, "Rhino3dm.dll"))

--- a/src/build_dotnet.py
+++ b/src/build_dotnet.py
@@ -42,7 +42,7 @@ def methodgen(dotnetcore):
         # compile methodgen
         system('dotnet build ' + './' + build_dir)
         # execute methodgen
-        system('dotnet ./'+build_dir+'/bin/Debug/netcoreapp2.2/methodgen.dll '+ args)
+        system('dotnet run --project ' + build_dir + '/methodgen.csproj ' + args)
     else:
         # compile methodgen
         system('msbuild ./methodgen')


### PR DESCRIPTION
@dbelcher I just noticed that build_dotnet.py was masking build errors, so I updated the linux dot builds to use the new scripts and updated the amazon linux docker image too.