### PR TITLE
Add Interval(double, double) constructor in python

### DIFF
--- a/src/bindings/bnd_point.cpp
+++ b/src/bindings/bnd_point.cpp
@@ -10,6 +10,12 @@ BND_Interval::BND_Interval(const ON_Interval& i)
   m_t1 = i.m_t[1];
 }
 
+BND_Interval::BND_Interval(double t0, double t1)
+{
+  m_t0 = t0;
+  m_t1 = t1;
+}
+
 ON_3dPoint BND_Point3d::Transform(const ON_3dPoint& pt, const BND_Transform& transform)
 {
   ON_3dPoint rc = transform.m_xform * pt;
@@ -162,6 +168,7 @@ void initPointBindings(pybind11::module& m)
     .def(py::self + py::self);
 
   py::class_<BND_Interval>(m, "Interval")
+    .def(py::init<double, double>(), py::arg("t0"), py::arg("t1"))
     .def_readwrite("T0", &BND_Interval::m_t0)
     .def_readwrite("T1", &BND_Interval::m_t1);
 

--- a/src/bindings/bnd_point.h
+++ b/src/bindings/bnd_point.h
@@ -13,6 +13,7 @@ class BND_Interval
 public:
   BND_Interval() = default;
   BND_Interval(const ON_Interval& i);
+  BND_Interval(double t0, double t1);
   double m_t0;
   double m_t1;
 };


### PR DESCRIPTION

This new constructor will make the following possible...

```
from rhino3dm import Plane, Interval, PlaneSurface
srf = PlaneSurface(Plane.WorldXY(), Interval(-1,1), Interval(-2,3))
```