### PR TITLE
Use emscripten v2.0.10 (latest)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,35 +12,9 @@ jobs:
       - run: git submodule update --init
       - run: python3 --version && emcc --version && cmake --version
       - run: python3 src/build_javascript.py
-      - persist_to_workspace:
-          root: src/build/artifacts_js
-          paths:
-            - .
-  deploy_js:
-    docker:
-      - image: circleci/python:2.7-jessie
-        auth:
-          username: $DOCKERHUB_USER
-          password: $DOCKERHUB_PASSWORD
-    environment:
-      S3_BASE_URL: s3://files.na.mcneel.com/rhino3dm/js
-    steps:
-      - attach_workspace:
-          at: src/build/artifacts_js
-      - run: ls -l src/build/artifacts_js
-      - run: python --version
-      - run: sudo pip install awscli
-        # upload artifacts to s3
-      - run: aws s3 cp src/build/artifacts_js $S3_BASE_URL/dujour/$CIRCLE_BUILD_NUM/ --recursive --acl public-read
-        # re-upload rhino3dm.wasm with mime-type "application/wasm"
-      - run: aws s3 cp src/build/artifacts_js/rhino3dm.wasm $S3_BASE_URL/dujour/$CIRCLE_BUILD_NUM/ --acl public-read --content-type "application/wasm"
-        # copy artifacts from dujour/$CIRCLE_BUILD_NUM/ to latest/
-      - run:
-          name: Copy artifacts to latest/
-          command: |
-            if [ "${CIRCLE_BRANCH}" = "master" ]; then
-              aws s3 cp $S3_BASE_URL/dujour/$CIRCLE_BUILD_NUM/ $S3_BASE_URL/latest/ --recursive --acl public-read
-            fi
+      - store_artifacts:
+          path: src/build/artifacts_js
+          destination: .
 
   build_py2:
     docker:
@@ -114,10 +88,6 @@ workflows:
       - build_js:
           context:
             - docker-hub-creds
-      # 2020-06-28: use jsdelivr instead of publishing to files.mcneel.com
-      # - deploy_js:
-      #     requires:
-      #       - build_js
       - build_py2:
           context:
             - docker-hub-creds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@ version: 2
 jobs:
   build_js:
     docker:
-      - image: trzeci/emscripten-ubuntu:sdk-incoming-64bit
+      - image: emscripten/emsdk:2.0.10
         auth:
           username: $DOCKERHUB_USER
           password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - run: git submodule update --init
-      - run: python --version && emcc --version && cmake --version
-      - run: python src/build_javascript.py
+      - run: python3 --version && emcc --version && cmake --version
+      - run: python3 src/build_javascript.py
       - persist_to_workspace:
           root: src/build/artifacts_js
           paths:

--- a/Current Development Tools.md
+++ b/Current Development Tools.md
@@ -52,9 +52,9 @@ We are currently using the Xamarin.Android Framework 10.1.3.  Scripts read this:
 
 ### Emscripten
 
-We are currently using Emscripten 1.39.5. Scripts read this:
+We are currently using Emscripten 2.0.10. Scripts read this:
 
-`emscripten_currently_using = 1.39.5`
+`emscripten_currently_using = 2.0.10`
 `emscripten_install_notes = To install Emscripten, follow these instructions: https://emscripten.org/docs/getting_started/downloads.html. You must activate PATH and other environment variables in the current terminal. You can verify the installation following these instructions: https://emscripten.org/docs/building_from_source/verify_emscripten_environment.html`
 `emscripten_install_notes_windows =  To install Emscripten, follow these instructions: https://emscripten.org/docs/getting_started/downloads.html. You must activate PATH and other environment variables in the current terminal.  You can verify the installation following these instructions: https://emscripten.org/docs/building_from_source/verify_emscripten_environment.html.  Be sure to use the --global flag when running the activate batch file to set all the path variables correctly.`
 


### PR DESCRIPTION
* Updates circleci build to use `emscripten/emsdk:2.0.10` docker image to build rhino3dm.js
* Adds rhino3dm.js and rhino3dm.wasm to build artifacts