### PR TITLE
Add support for mesh texture coordinates.

### DIFF
--- a/src/bindings/bnd_mesh.cpp
+++ b/src/bindings/bnd_mesh.cpp
@@ -792,6 +792,12 @@ ON_2fPoint* BND_MeshTextureCoordinateList::end()
   return m_mesh->m_T.At(count - 1);
 }
 
+int BND_MeshTextureCoordinateList::Add(float s, float t)
+{
+  m_mesh->SetTextureCoord(m_mesh->m_T.Count(), s, t);
+  return m_mesh->m_T.Count() - 1;
+}
+
 
 #if defined(ON_PYTHON_COMPILE)
 namespace py = pybind11;
@@ -901,6 +907,7 @@ void initMeshBindings(pybind11::module& m)
     .def("__len__", &BND_MeshTextureCoordinateList::Count)
     .def("__getitem__", &BND_MeshTextureCoordinateList::GetTextureCoordinate)
     .def("__setitem__", &BND_MeshTextureCoordinateList::SetTextureCoordinate)
+    .def("__add__", &BND_MeshTextureCoordinateList::Add)
     .def("__iter__", [](BND_MeshTextureCoordinateList &s) { return py::make_iterator(s.begin(), s.end()); },
       py::keep_alive<0, 1>() /* Essential: keep object alive while iterator exists */)
     ;
@@ -1037,6 +1044,7 @@ void initMeshBindings(void*)
     .property("count", &BND_MeshTextureCoordinateList::Count)
     .function("get", &BND_MeshTextureCoordinateList::GetTextureCoordinate)
     .function("set", &BND_MeshTextureCoordinateList::SetTextureCoordinate)
+    .function("add", &BND_MeshTextureCoordinateList::Add)
     ;
 
   class_<BND_Mesh, base<BND_GeometryBase>>("Mesh")

--- a/src/bindings/bnd_mesh.h
+++ b/src/bindings/bnd_mesh.h
@@ -280,6 +280,7 @@ public:
   int Count() const { return m_mesh->m_T.Count(); }
   ON_2fPoint GetTextureCoordinate(int i) const { return m_mesh->m_T[i]; }
   void SetTextureCoordinate(int i, ON_2fPoint tc) { m_mesh->m_T[i] = tc; }
+  int Add(float s, float t);
 };
 
 

--- a/src/bindings/bnd_point.cpp
+++ b/src/bindings/bnd_point.cpp
@@ -206,6 +206,10 @@ void initPointBindings(void*)
     .element(&ON_3dVector::y)
     .element(&ON_3dVector::z);
 
+  value_array<ON_2fPoint>("Point2fSimple")
+    .element(&ON_2fPoint::x)
+    .element(&ON_2fPoint::y);
+
   value_array<ON_3fPoint>("Point3fSimple")
     .element(&ON_3fPoint::x)
     .element(&ON_3fPoint::y)


### PR DESCRIPTION
I had to add some functionality to complete support of mesh texture coordinates:

- The javascript build was missing a binding for 2fPoint.
- Added the Add function for mesh texture coordinates. Similar to the vertex and normal list.

Please let me know if I'm forgetting something or if I need to update any documentation.

Tested it on my end with rhino-compute.