### PR TITLE
Fix ToByteArray memory corruption.

### DIFF
--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -1139,11 +1139,10 @@ emscripten::val BND_ONXModel::ToByteArray2(const BND_File3dmWriteOptions* option
   m_model->Write(archive, options->VersionForWriting());
   const unsigned char* buffer = (const unsigned char*)archive.Buffer();
   size_t length = archive.SizeOfArchive();
-  
-  unsigned char* ret_buffer = new unsigned char[length];
-  memcpy (ret_buffer, buffer, length);
-  
-  return emscripten::val(emscripten::typed_memory_view(length, ret_buffer));
+
+  emscripten::val Uint8Array = emscripten::val::global("Uint8Array");
+  emscripten::val rc = Uint8Array.new_(emscripten::typed_memory_view(length, buffer));
+  return rc;
 }
 
 #endif

--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -1140,10 +1140,10 @@ emscripten::val BND_ONXModel::ToByteArray2(const BND_File3dmWriteOptions* option
   const unsigned char* buffer = (const unsigned char*)archive.Buffer();
   size_t length = archive.SizeOfArchive();
   
-  unsigned char* retBuffer = new unsigned char[length];
-  memcpy (retBuffer, buffer, length);
+  unsigned char* ret_buffer = new unsigned char[length];
+  memcpy (ret_buffer, buffer, length);
   
-  return emscripten::val(emscripten::typed_memory_view(length, retBuffer));
+  return emscripten::val(emscripten::typed_memory_view(length, ret_buffer));
 }
 
 #endif

--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -1139,16 +1139,11 @@ emscripten::val BND_ONXModel::ToByteArray2(const BND_File3dmWriteOptions* option
   m_model->Write(archive, options->VersionForWriting());
   const unsigned char* buffer = (const unsigned char*)archive.Buffer();
   size_t length = archive.SizeOfArchive();
-
-  emscripten::val Uint8Array = emscripten::val::global("Uint8Array");
-  emscripten::val rc = Uint8Array.new_(emscripten::val::module_property("HEAPU8")["buffer"], size_t(buffer), length);
-  for (size_t i = 0; i < length; i++)
-  {
-    rc.set(i, buffer[i]);
-  }
-  //  rc.call<void>("set", sourceTypedArray);
-  //  std::string rc(reinterpret_cast<char const*>(buffer), length);
-  return rc;
+  
+  unsigned char* retBuffer = new unsigned char[length];
+  memcpy (retBuffer, buffer, length);
+  
+  return emscripten::val(emscripten::typed_memory_view(length, retBuffer));
 }
 
 #endif


### PR DESCRIPTION
It should fix the memory corruption in the toByteArray function called from javascript.

**Error**
The previous approach just created a view on the buffer that is owned by the `ON_Write3dmBufferArchive` class. At the end of the `ToByteArray2` function the memory is freed by the owner. So it was the question of luck if it works or not.

**Solution**
Now I create a new buffer for the result, and copy the original buffer content to it. Returning of this value is somewhat cleaner than the original solution. To be honest it introduces another problem: Who will free this memory up? I don't have a solution for that right now (maybe another function that should be called when the buffer is not needed anymore), but at least now it works as expected.

**Fixes**
- Sure:
  - https://discourse.mcneel.com/t/rhino3dm-js-fails-to-write-a-single-cube-to-a-3dm-file/123467/2
- Probably:
  - https://discourse.mcneel.com/t/rhino3dm-js-fails-to-write-a-single-cube-to-a-3dm-file/123467/2
  - https://discourse.mcneel.com/t/rhino3dm-threejs-geometry-import-failing/118635
  - toByteArray produces invalid 3dm file in some cases #353