### PR TITLE
Make Emscripten build work on Windows

### DIFF
--- a/docs/javascript/RHINO3DM-BUILD.JS.md
+++ b/docs/javascript/RHINO3DM-BUILD.JS.md
@@ -27,6 +27,10 @@ A number of scripts are used to setup and build rhino3dm:
 
 These scripts support Python 2 and 3 on Windows (linux subsystem), macOS, or Linux (Ubuntu).
 
+### Before running scripts
+
+You have to make sure that Emscripten environment is set up. On windows it can be done by running `emsdk_env.bat` before running the scripts.
+
 ### bootstrap.py
 
 The `script/bootstrap.py` script can be used to check your system for (and, in some cases, download) the necessary tools for a specific build target.  For example, you can run:

--- a/docs/javascript/RHINO3DM-BUILD.JS.md
+++ b/docs/javascript/RHINO3DM-BUILD.JS.md
@@ -35,9 +35,8 @@ You have to make sure that the Emscripten environment is set up. Here are the st
 git clone https://github.com/emscripten-core/emsdk.git
 cd emsdk
 git pull
-git checkout tags/2.0.5
-emsdk install 2.0.5
-emsdk activate 2.0.5
+emsdk install latest
+emsdk activate latest
 emsdk install mingw-4.6.2-32bit
 emsdk activate mingw-4.6.2-32bit
 ```

--- a/docs/javascript/RHINO3DM-BUILD.JS.md
+++ b/docs/javascript/RHINO3DM-BUILD.JS.md
@@ -27,9 +27,20 @@ A number of scripts are used to setup and build rhino3dm:
 
 These scripts support Python 2 and 3 on Windows (linux subsystem), macOS, or Linux (Ubuntu).
 
-### Before running scripts
+### Running scripts on Windows
 
-You have to make sure that Emscripten environment is set up. On windows it can be done by running `emsdk_env.bat` before running the scripts.
+You have to make sure that the Emscripten environment is set up. Here are the steps to install Emscripten and the make tool to make it work. After that you can set up the environment by running `emsdk_env.bat`.
+
+```
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk
+git pull
+git checkout tags/2.0.5
+emsdk install 2.0.5
+emsdk activate 2.0.5
+emsdk install mingw-4.6.2-32bit
+emsdk activate mingw-4.6.2-32bit
+```
 
 ### bootstrap.py
 

--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -364,6 +364,10 @@ def check_xcode(build_tool):
 
 
 def check_emscripten(build_tool):
+    def version_from_emscripten_output (output):
+        first_line = output.splitlines()[0]
+        return re.match (r".*([0-9]+\.[0-9]+\.[0-9]+).*", first_line).group (1)
+        
     print_check_preamble(build_tool)
 
     # check to make sure that the $EMSDK path variable has been set
@@ -389,7 +393,7 @@ def check_emscripten(build_tool):
         return False
         
     if sys.version_info[0] < 3:
-        running_version = p.communicate()[0].splitlines()[0].split()[4]
+        running_version = version_from_emscripten_output (p.communicate()[0])
         if not running_version:
             print_error_message(build_tool.name + " not found." + format_install_instructions(build_tool))
             return False
@@ -398,7 +402,7 @@ def check_emscripten(build_tool):
         if err:
             print_error_message(err)
             return False
-        running_version = running_version.decode('utf-8').splitlines()[0].split()[4]
+        running_version = version_from_emscripten_output (running_version.decode('utf-8'))
 
     print_version_comparison(build_tool, running_version)
 

--- a/script/build.py
+++ b/script/build.py
@@ -32,6 +32,7 @@ import time
 xcode_logging = False
 verbose = False
 overwrite = False
+popen_shell_mode = False
 valid_platform_args = ["windows", "linux", "macos", "ios", "android", "js", "python"]
 platform_full_names = {'windows':'Windows', 'linux':'Linux', 'macos': 'macOS', 'ios': 'iOS', 'android': 'Android', 'js': 'JavaScript' }
 script_folder = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
@@ -98,9 +99,9 @@ def print_platform_preamble(platform_target_name):
 def run_command(command, suppress_errors=False):
     if suppress_errors == True:                
         dev_null = open(os.devnull, 'w')
-        process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=dev_null)
+        process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=dev_null, shell=popen_shell_mode)
     else:
-        process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE)    
+        process = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=popen_shell_mode)    
     
     while True:
         line = process.stdout.readline()               
@@ -439,14 +440,14 @@ def build_js():
 
     if overwrite:
         try:
-            subprocess.Popen(['make', 'clean'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+            subprocess.Popen(['make', 'clean'], stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=popen_shell_mode)
         except OSError:
             print_error_message("unable to run make clean in " + target_path)
             return False
 
     # The javascript make build hangs after about 10 lines when outputting stderr the pipe so
     # we'll pass suppress_errors argument as True here...
-    run_command("make", True)
+    run_command("emmake make", True)
 
     # Check to see if the build succeeded and move into artifacts_js
     items_to_check = ['rhino3dm.wasm', 'rhino3dm.js']
@@ -523,8 +524,10 @@ def main():
     global xcode_logging
     xcode_logging = args.xcodelog
 
+    global popen_shell_mode
     if _platform == "win32":
         xcode_logging = True
+        popen_shell_mode = True
 
     global verbose
     verbose = args.verbose

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -484,7 +484,7 @@ if(${RHINO3DM_JS})
   # we will eventually want the following warnging flags on both compiles
   # for now, just WASM
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-overloaded-virtual -Wno-switch -Wno-unknown-pragmas -Wno-unused-private-field")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s MODULARIZE=1 -s 'EXPORT_NAME=\"rhino3dm\"'")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s MODULARIZE=1 -s EXPORT_NAME=rhino3dm")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -s ALLOW_MEMORY_GROWTH=1 --bind")
 endif()
 #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")


### PR DESCRIPTION
While I was trying to compile rhino3dm.js on Windows I've struggled with some things in the script.

This pull request contains my modifications to make it work on Windows:
- Extended the build instructions in the readme.
- Fixed Emscripten version detection.
- When using `subprocess.Popen` the shell parameter must be true so the subprocess will inherit environment variables. I modified it only on Windows, because it is usually a source of platform specific errors.
- Use `emmake` helper to build with Emscripten so the `make` tool shouldn't be in the PATH.
- The call `shlex.split` must have the posix parameter set to false on Windows.