### PR TITLE
Add support for reading linked instance definitions

### DIFF
--- a/src/bindings/bnd_instance.cpp
+++ b/src/bindings/bnd_instance.cpp
@@ -61,11 +61,20 @@ BND_Transform BND_InstanceReferenceGeometry::Xform() const
 namespace py = pybind11;
 void initInstanceBindings(pybind11::module& m)
 {
+  py::enum_<InstanceDefinitionUpdateType>(m, "InstanceDefinitionUpdateType")
+    .value("Static", InstanceDefinitionUpdateType::Static)
+    .value("Embedded", InstanceDefinitionUpdateType::Embedded)
+    .value("LinkedAndEmbedded", InstanceDefinitionUpdateType::LinkedAndEmbedded)
+    .value("Linked", InstanceDefinitionUpdateType::Linked)
+    ;
+  
   py::class_<BND_InstanceDefinitionGeometry, BND_CommonObject>(m, "InstanceDefinition")
     .def(py::init<>())
     .def_property_readonly("Description", &BND_InstanceDefinitionGeometry::Description)
     .def_property_readonly("Name", &BND_InstanceDefinitionGeometry::Name)
     .def_property_readonly("Id", &BND_InstanceDefinitionGeometry::Id)
+    .def_property_readonly("SourceArchive", &BND_InstanceDefinitionGeometry::SourceArchive)
+    .def_property_readonly("UpdateType", &BND_InstanceDefinitionGeometry::UpdateType)
     .def("GetObjectIds", &BND_InstanceDefinitionGeometry::GetObjectIds)
     .def("IsInstanceGeometryId", &BND_InstanceDefinitionGeometry::IsInstanceGeometryId, py::arg("id"))
     ;
@@ -83,11 +92,20 @@ using namespace emscripten;
 
 void initInstanceBindings(void*)
 {
+  enum_<InstanceDefinitionUpdateType>("InstanceDefinitionUpdateType")
+    .value("Static", InstanceDefinitionUpdateType::Static)
+    .value("Embedded", InstanceDefinitionUpdateType::Embedded)
+    .value("LinkedAndEmbedded", InstanceDefinitionUpdateType::LinkedAndEmbedded)
+    .value("Linked", InstanceDefinitionUpdateType::Linked)
+    ;
+
   class_<BND_InstanceDefinitionGeometry, base<BND_CommonObject>>("InstanceDefinition")
     .constructor<>()
     .property("description", &BND_InstanceDefinitionGeometry::Description)
     .property("name", &BND_InstanceDefinitionGeometry::Name)
     .property("id", &BND_InstanceDefinitionGeometry::Id)
+    .property("sourceArchive", &BND_InstanceDefinitionGeometry::SourceArchive)
+    .property("updateType", &BND_InstanceDefinitionGeometry::UpdateType)
     .function("getObjectIds", &BND_InstanceDefinitionGeometry::GetObjectIds)
     .function("isInstanceGeometryId", &BND_InstanceDefinitionGeometry::IsInstanceGeometryId)
     ;

--- a/src/bindings/bnd_instance.cpp
+++ b/src/bindings/bnd_instance.cpp
@@ -1,5 +1,25 @@
 #include "bindings.h"
 
+InstanceDefinitionUpdateType ON_UPDATE_TYPE_to_Binding(const ON_InstanceDefinition::IDEF_UPDATE_TYPE ON_type)
+{
+  InstanceDefinitionUpdateType type;
+  switch (ON_type)
+  {
+    case ON_InstanceDefinition::IDEF_UPDATE_TYPE::Static:
+      type = InstanceDefinitionUpdateType::Static;
+      break;
+    case ON_InstanceDefinition::IDEF_UPDATE_TYPE::LinkedAndEmbedded:
+      type = InstanceDefinitionUpdateType::LinkedAndEmbedded;
+      break;
+    case ON_InstanceDefinition::IDEF_UPDATE_TYPE::Linked:
+      type = InstanceDefinitionUpdateType::Linked;
+      break;
+    default:
+      type = InstanceDefinitionUpdateType::Static;
+  }
+  return type;
+}
+
 BND_InstanceDefinitionGeometry::BND_InstanceDefinitionGeometry(ON_InstanceDefinition* idef, const ON_ModelComponentReference* compref)
 {
   SetTrackedPointer(idef, compref);

--- a/src/bindings/bnd_instance.h
+++ b/src/bindings/bnd_instance.h
@@ -10,6 +10,8 @@ enum class InstanceDefinitionUpdateType : int
   Linked = 3
 };
 
+InstanceDefinitionUpdateType ON_UPDATE_TYPE_to_Binding(const ON_InstanceDefinition::IDEF_UPDATE_TYPE ON_type);
+
 #if defined(ON_PYTHON_COMPILE)
 void initInstanceBindings(pybind11::module& m);
 #else
@@ -30,7 +32,7 @@ public:
   std::wstring Name() const { return std::wstring(m_idef->Name()); }
   BND_UUID Id() const { return ON_UUID_to_Binding(m_idef->Id()); }
   std::wstring SourceArchive() const { return std::wstring(m_idef->LinkedFilePath()); }
-  InstanceDefinitionUpdateType UpdateType() const { return InstanceDefinitionUpdateType(m_idef->InstanceDefinitionType()); }
+  InstanceDefinitionUpdateType UpdateType() const { return ON_UPDATE_TYPE_to_Binding(m_idef->InstanceDefinitionType()); }
   BND_TUPLE GetObjectIds() const;
   bool IsInstanceGeometryId(BND_UUID id) const { return m_idef->IsInstanceGeometryId(Binding_to_ON_UUID(id));}
 };

--- a/src/bindings/bnd_instance.h
+++ b/src/bindings/bnd_instance.h
@@ -2,6 +2,14 @@
 
 #pragma once
 
+enum class InstanceDefinitionUpdateType : int
+{
+  Static = 0,
+  Embedded = 1,
+  LinkedAndEmbedded = 2,
+  Linked = 3
+};
+
 #if defined(ON_PYTHON_COMPILE)
 void initInstanceBindings(pybind11::module& m);
 #else
@@ -21,6 +29,8 @@ public:
   std::wstring Description() const { return std::wstring(m_idef->Description()); }
   std::wstring Name() const { return std::wstring(m_idef->Name()); }
   BND_UUID Id() const { return ON_UUID_to_Binding(m_idef->Id()); }
+  std::wstring SourceArchive() const { return std::wstring(m_idef->LinkedFilePath()); }
+  InstanceDefinitionUpdateType UpdateType() const { return InstanceDefinitionUpdateType(m_idef->InstanceDefinitionType()); }
   BND_TUPLE GetObjectIds() const;
   bool IsInstanceGeometryId(BND_UUID id) const { return m_idef->IsInstanceGeometryId(Binding_to_ON_UUID(id));}
 };


### PR DESCRIPTION
This change adds the [SourceArchive](https://developer.rhino3d.com/api/RhinoCommon/html/P_Rhino_DocObjects_InstanceDefinition_SourceArchive.htm) and [UpdateType](https://developer.rhino3d.com/api/RhinoCommon/html/P_Rhino_DocObjects_InstanceDefinition_UpdateType.htm) properties to the [InstanceDefinition](https://developer.rhino3d.com/api/RhinoCommon/html/T_Rhino_DocObjects_InstanceDefinition.htm) bindings. It also exposes the [InstanceDefinitionUpdateType](https://developer.rhino3d.com/api/RhinoCommon/html/T_Rhino_DocObjects_InstanceDefinitionUpdateType.htm) enum.

Together, these properties allow rhino3dm users to load geometries from linked instance definitions by finding and opening the linked file.

---

Closes #367 