### PR TITLE
Bindings: Fix doc.strings().count() property for js

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -65,7 +65,7 @@ jobs:
       - name: artifacts
         uses: actions/upload-artifact@v2
         with:
-          path: src/build/artifacts_js
+          path: src/build/javascript/artifacts_js
           name: rhino3dm.js
 
   build_py2:

--- a/src/bindings/bnd_3dm_settings.cpp
+++ b/src/bindings/bnd_3dm_settings.cpp
@@ -1,5 +1,6 @@
 #include "bindings.h"
 
+
 BND_Viewport* BND_ViewInfo::GetViewport() const
 {
   return new BND_Viewport(new ON_Viewport(m_view.m_vp), nullptr);

--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -1545,7 +1545,7 @@ void initExtensionsBindings(void*)
     .function("get", &BND_File3dmStringTable::GetKeyValue)
     .function("getvalue", &BND_File3dmStringTable::GetValueFromKey)
     .function("set", &BND_File3dmStringTable::SetString)
-    .function("count", &BND_File3dmStringTable::DocumentUserTextCount)
+    .function("documentUserTextCount", &BND_File3dmStringTable::DocumentUserTextCount)
     .function("delete", &BND_File3dmStringTable::Delete)
     ;
 


### PR DESCRIPTION
Fixes #303. 

The property name `count` for doc.strings().count() was used twice, once for doc.strings().count() and then used again for doc.strings().documentUserTextCount(). Fixed by adding `documentUserTextCount` as the property name. 