### PR TITLE
Generate rhino3dm.module.js in post-build step

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -38,7 +38,9 @@ jobs:
         uses: tj-actions/changed-files@v6.3
         id: changed-files
         with:
-          files: src/bindings
+          files: |
+            src/bindings
+            src/CMakeLists.txt
 
   #Only run if src files have changed.
 

--- a/script/build.py
+++ b/script/build.py
@@ -450,7 +450,7 @@ def build_js():
     run_command("emmake make", True)
 
     # Check to see if the build succeeded and move into artifacts_js
-    items_to_check = ['rhino3dm.wasm', 'rhino3dm.js']
+    items_to_check = ['rhino3dm.wasm', 'rhino3dm.js', 'rhino3dm.module.js']
     all_items_built = True
     for item in items_to_check:
         path_to_item = os.path.abspath(os.path.join(target_path, item))

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -544,3 +544,16 @@ if(${RHINO3DM_JS})
   install(FILES "build/javascript/rhino3dm.js" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/build/artifacts_js")
   install(FILES "build/javascript/rhino3dm.wasm" DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}/build/artifacts_js")
 endif()
+
+# patch rhino3dm.js using the supplied diff to produce rhino3dm.module.js
+if(${RHINO3DM_JS})
+  find_program(PATCH patch)
+  if(NOT PATCH)
+      message(WARNING "rhino3dm.module.js generation will fail: patch not found!")
+  endif()
+  add_custom_command(TARGET rhino3dm POST_BUILD
+    COMMENT "Generating ${CMAKE_BINARY_DIR}/rhino3dm.module.js"
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:rhino3dm> ${CMAKE_BINARY_DIR}/rhino3dm.module.js
+    COMMAND ${PATCH} ${CMAKE_BINARY_DIR}/rhino3dm.module.js ${CMAKE_CURRENT_SOURCE_DIR}/rhino3dm.module.js.diff
+  )
+endif()

--- a/src/rhino3dm.module.js.diff
+++ b/src/rhino3dm.module.js.diff
@@ -1,0 +1,24 @@
+--- rhino3dm.js	1985-10-26 09:15:00.000000000 +0100
++++ rhino3dm.module.js	1985-10-26 09:15:00.000000000 +0100
+@@ -1,7 +1,7 @@
+ 
+ var rhino3dm = (function() {
+-  var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
+-  if (typeof __filename !== 'undefined') _scriptDir = _scriptDir || __filename;
++  var _scriptDir = import.meta.url;
++  
+   return (
+ function(rhino3dm) {
+   rhino3dm = rhino3dm || {};
+@@ -13,9 +13,4 @@
+ }
+ );
+ })();
+-if (typeof exports === 'object' && typeof module === 'object')
+-  module.exports = rhino3dm;
+-else if (typeof define === 'function' && define['amd'])
+-  define([], function() { return rhino3dm; });
+-else if (typeof exports === 'object')
+-  exports["rhino3dm"] = rhino3dm;
++export default rhino3dm;
+\ No newline at end of file


### PR DESCRIPTION
Generates rhino3dm.module.js by applying a patch (assuming `patch` is on the `$PATH`) to rhino3dm.js. This is handled by cmake in a post-build step.