### PR TITLE
Add bindings for linetypes

### DIFF
--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -69,6 +69,7 @@ EMSCRIPTEN_BINDINGS(rhino3dm) {
   initExtensionsBindings(m);
   initDracoBindings(m);
   initRTreeBindings(m);
+  initLinetypeBindings(m);
 }
 
 BND_TUPLE CreateTuple(int count)

--- a/src/bindings/bindings.h
+++ b/src/bindings/bindings.h
@@ -104,3 +104,4 @@ void SetTuple(BND_TUPLE& tuple, int index, const T& value)
 #include "bnd_extensions.h"
 #include "bnd_draco.h"
 #include "bnd_rtree.h"
+#include "bnd_linetype.h"

--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -702,6 +702,117 @@ BND_Material* BND_File3dmMaterialTable::FromAttributes(const BND_3dmObjectAttrib
   return nullptr;
 }
 
+
+void BND_File3dmLinetypeTable::Add(const BND_Linetype& linetype)
+{
+  const ON_Linetype* l = linetype.m_linetype;
+  m_model->AddModelComponent(*l);
+}
+
+void BND_File3dmLinetypeTable::Delete(BND_UUID id)
+{
+  ON_UUID _id = Binding_to_ON_UUID(id);
+  m_model->RemoveModelComponent(ON_ModelComponent::Type::LinePattern, _id);
+}
+
+BND_Linetype* BND_File3dmLinetypeTable::IterIndex(int index)
+{
+  return FindIndex(index);
+}
+
+template<typename ON_Type, typename BND_Type>
+BND_Type* bindingFromCompRef(ON_ModelComponentReference compref)
+{
+  const ON_ModelComponent* model_component = compref.ModelComponent();
+  if (compref.IsEmpty())
+    return nullptr;
+  ON_Type* model_object = const_cast<ON_Type*>(ON_Type::Cast(model_component));
+  if (model_object)
+    return new BND_Type(model_object, &compref);
+  return nullptr;
+}
+
+BND_Linetype* BND_File3dmLinetypeTable::FindIndex(int index)
+{
+  if (index >= 0)
+  {
+    ON_ModelComponentReference compref = m_model->ComponentFromIndex(ON_ModelComponent::Type::LinePattern, index); //no specific method in ON Extensions, therefore getting component here
+    return bindingFromCompRef<ON_Linetype, BND_Linetype>(compref);
+  }
+  if (index == ON_Linetype::Continuous.Index()) // -1
+    return new BND_Linetype(ON_Linetype::Continuous);
+  if (index == ON_Linetype::ByLayer.Index()) // -2
+    return new BND_Linetype(ON_Linetype::ByLayer);
+  if (index == ON_Linetype::ByParent.Index()) // -3
+    return new BND_Linetype(ON_Linetype::ByParent);
+  if (index == ON_Linetype::Hidden.Index()) // -4
+    return new BND_Linetype(ON_Linetype::Hidden);
+  if (index == ON_Linetype::Dashed.Index()) // -5
+    return new BND_Linetype(ON_Linetype::Dashed);
+  if (index == ON_Linetype::DashDot.Index()) // -6
+    return new BND_Linetype(ON_Linetype::DashDot);
+  if (index == ON_Linetype::Center.Index()) // -7
+    return new BND_Linetype(ON_Linetype::Center);
+  if (index == ON_Linetype::Border.Index()) // -8
+    return new BND_Linetype(ON_Linetype::Border);
+  if (index == ON_Linetype::Dots.Index()) // -9
+    return new BND_Linetype(ON_Linetype::Dots);
+  return nullptr;
+}
+
+BND_Linetype* BND_File3dmLinetypeTable::FindId(BND_UUID id)
+{
+  ON_UUID _id = Binding_to_ON_UUID(id);
+  ON_ModelComponentReference compref = m_model->LinePatternFromId(_id);
+  return bindingFromCompRef<ON_Linetype, BND_Linetype>(compref);
+}
+
+BND_Linetype* BND_File3dmLinetypeTable::FindName(std::wstring name)
+{
+  ON_ModelComponentReference compref = m_model->LinePatternFromName(name.c_str());
+  return bindingFromCompRef<ON_Linetype, BND_Linetype>(compref);
+}
+
+BND_Linetype* BND_File3dmLinetypeTable::FromAttributes(const BND_3dmObjectAttributes* attributes)
+{
+  ON_ModelComponentReference compref = m_model->LinePatternFromAttributes(*attributes->m_attributes);
+  return bindingFromCompRef<ON_Linetype, BND_Linetype>(compref);
+}
+
+BND_Linetype* BND_File3dmLinetypeTable::FromLayerIndex(int index)
+{
+  ON_ModelComponentReference compref = m_model->LinePatternFromLayerIndex(index);
+  return bindingFromCompRef<ON_Linetype, BND_Linetype>(compref);
+}
+
+BND_Linetype* BND_File3dmLinetypeTable::GetCurrent()
+{
+  // V6 and later stores the ID of the current linetype
+  ON_UUID _id = m_model->m_settings.CurrentLinePatternId();
+  if (_id != ON_nil_uuid)
+  {
+    ON_ModelComponentReference compref = m_model->LinePatternFromId(_id);
+    return bindingFromCompRef<ON_Linetype, BND_Linetype>(compref);
+  }
+  // V5 and earlier store the index of the current linetype
+  int _index = m_model->m_settings.CurrentLinePatternIndex();
+  if (_index != ON_UNSET_INT_INDEX)
+  {
+    return FindIndex(_index);
+  }
+  return nullptr;
+}
+
+void BND_File3dmLinetypeTable::SetCurrent(BND_Linetype* linetype)
+{
+  if (linetype->IsValid() && linetype->GetIndex() >= 0)
+  {
+    ON_UUID _id = linetype->m_linetype->Id();
+    m_model->m_settings.SetCurrentLinePatternId(_id);
+  }
+}
+
+
 void BND_File3dmBitmapTable::Add(const BND_Bitmap& bitmap)
 {
   const ON_Bitmap* b = bitmap.m_bitmap;
@@ -1293,6 +1404,28 @@ void initExtensionsBindings(pybind11::module& m)
     .def("FindFromAttributes", &BND_File3dmMaterialTable::FromAttributes)
     ;
 
+  py::class_<PyBNDIterator<BND_File3dmLinetypeTable&, BND_Linetype*> >(m, "__LinetypeIterator")
+    .def("__iter__", [](PyBNDIterator<BND_File3dmLinetypeTable&, BND_Linetype*> &it) -> PyBNDIterator<BND_File3dmLinetypeTable&, BND_Linetype*>& { return it; })
+    .def("__next__", &PyBNDIterator<BND_File3dmLinetypeTable&, BND_Linetype*>::next)
+    ;
+
+  py::class_<BND_File3dmLinetypeTable>(m, "File3dmLinetypeTable")
+    .def("__len__", &BND_File3dmLinetypeTable::Count)
+    .def("__getitem__", static_cast<BND_Linetype* (BND_File3dmLinetypeTable::*)(int)>(&BND_File3dmLinetypeTable::FindIndex))
+    .def("__getitem__", static_cast<BND_Linetype* (BND_File3dmLinetypeTable::*)(BND_UUID)>(&BND_File3dmLinetypeTable::FindId))
+    .def("__iter__", [](py::object s) { return PyBNDIterator<BND_File3dmLinetypeTable&, BND_Linetype*>(s.cast<BND_File3dmLinetypeTable &>(), s); })
+    .def("Add", &BND_File3dmLinetypeTable::Add, py::arg("linetype"))
+    .def("Delete", &BND_File3dmLinetypeTable::Delete, py::arg("id"))
+    .def("FindIndex", &BND_File3dmLinetypeTable::FindIndex, py::arg("index"))
+    .def("FindId", &BND_File3dmLinetypeTable::FindId, py::arg("id"))
+    .def("FindName", &BND_File3dmLinetypeTable::FindName, py::arg("name"))
+    .def("FromAttributes", &BND_File3dmLinetypeTable::FromAttributes, py::arg("attributes"))
+    .def("FromLayerIndex", &BND_File3dmLinetypeTable::FromLayerIndex, py::arg("index"))
+    .def_property("Current", &BND_File3dmLinetypeTable::GetCurrent, &BND_File3dmLinetypeTable::SetCurrent)
+    .def_property("CurrentSource", &BND_File3dmLinetypeTable::GetCurrentSource, &BND_File3dmLinetypeTable::SetCurrentSource)
+    .def_property("Scale", &BND_File3dmLinetypeTable::GetScale, &BND_File3dmLinetypeTable::SetScale)
+    ;
+
   py::class_<PyBNDIterator<BND_File3dmBitmapTable&, BND_Bitmap*> >(m, "__ImageIterator")
     .def("__iter__", [](PyBNDIterator<BND_File3dmBitmapTable&, BND_Bitmap*>  &it) -> PyBNDIterator<BND_File3dmBitmapTable&, BND_Bitmap*> & { return it; })
     .def("__next__", &PyBNDIterator<BND_File3dmBitmapTable&, BND_Bitmap*> ::next)
@@ -1415,6 +1548,7 @@ void initExtensionsBindings(pybind11::module& m)
     .def_property_readonly("Settings", &BND_ONXModel::Settings)
     .def_property_readonly("Objects", &BND_ONXModel::Objects)
     .def_property_readonly("Materials", &BND_ONXModel::Materials)
+    .def_property_readonly("Linetypes", &BND_ONXModel::Linetypes)
     .def_property_readonly("Bitmaps", &BND_ONXModel::Bitmaps)
     .def_property_readonly("Layers", &BND_ONXModel::Layers)
     .def_property_readonly("Groups", &BND_ONXModel::AllGroups)
@@ -1488,6 +1622,18 @@ void initExtensionsBindings(void*)
     .function("findIndex", &BND_File3dmMaterialTable::FindIndex, allow_raw_pointers())
     .function("findId", &BND_File3dmMaterialTable::FindId, allow_raw_pointers())
     .function("findFromAttributes", &BND_File3dmMaterialTable::FromAttributes, allow_raw_pointers())
+    ;
+
+  class_<BND_File3dmLinetypeTable>("File3dmLinetypeTable")
+    .function("count", &BND_File3dmLinetypeTable::Count)
+    .function("get", &BND_File3dmLinetypeTable::FindIndex, allow_raw_pointers())
+    .function("add", &BND_File3dmLinetypeTable::Add)
+    .function("delete", &BND_File3dmLinetypeTable::Delete)
+    .function("findIndex", &BND_File3dmLinetypeTable::FindIndex, allow_raw_pointers())
+    .function("findId", &BND_File3dmLinetypeTable::FindId, allow_raw_pointers())
+    .function("findName", &BND_File3dmLinetypeTable::FindName, allow_raw_pointers())
+    .function("fromAttributes", &BND_File3dmLinetypeTable::FromAttributes, allow_raw_pointers())
+    .function("fromLayerIndex", &BND_File3dmLinetypeTable::FromLayerIndex, allow_raw_pointers())
     ;
 
   class_<BND_File3dmBitmapTable>("File3dmBitmapTable")
@@ -1569,6 +1715,7 @@ void initExtensionsBindings(void*)
     .function("settings", &BND_ONXModel::Settings)
     .function("objects", &BND_ONXModel::Objects)
     .function("materials", &BND_ONXModel::Materials)
+    .function("linetypes", &BND_ONXModel::Linetypes)
     .function("bitmaps", &BND_ONXModel::Bitmaps)
     .function("layers", &BND_ONXModel::Layers)
     .function("groups", &BND_ONXModel::AllGroups)

--- a/src/bindings/bnd_extensions.h
+++ b/src/bindings/bnd_extensions.h
@@ -102,6 +102,28 @@ public:
   class BND_Material* FromAttributes(const class BND_3dmObjectAttributes* attributes);
 };
 
+class BND_File3dmLinetypeTable
+{
+  std::shared_ptr<ONX_Model> m_model;
+public:
+  BND_File3dmLinetypeTable(std::shared_ptr<ONX_Model> m) { m_model = m; }
+  int Count() const { return m_model.get()->ActiveComponentCount(ON_ModelComponent::Type::LinePattern); }
+  void Add(const class BND_Linetype& linetype);
+  void Delete(BND_UUID id);
+  class BND_Linetype* FindIndex(int index);
+  class BND_Linetype* IterIndex(int index); // helper function for iterator
+  class BND_Linetype* FindId(BND_UUID id);
+  class BND_Linetype* FindName(std::wstring name);
+  class BND_Linetype* FromAttributes(const BND_3dmObjectAttributes*);
+  class BND_Linetype* FromLayerIndex(int index);
+  class BND_Linetype* GetCurrent();
+  void SetCurrent(BND_Linetype* linetype);
+  ON::object_linetype_source GetCurrentSource() { return m_model->m_settings.m_current_linetype_source; }
+  void SetCurrentSource(ON::object_linetype_source source) { m_model->m_settings.m_current_linetype_source = source; }
+  double GetScale() const { return m_model->m_settings.m_linetype_display_scale; }
+  void SetScale(double scale) { m_model->m_settings.m_linetype_display_scale = scale; }
+};
+
 class BND_File3dmBitmapTable
 {
   std::shared_ptr<ONX_Model> m_model;
@@ -279,7 +301,7 @@ public:
 
   BND_ONXModel_ObjectTable Objects() { return BND_ONXModel_ObjectTable(m_model); }
   BND_File3dmMaterialTable Materials() { return BND_File3dmMaterialTable(m_model); }
-  //public File3dmLinetypeTable AllLinetypes
+  BND_File3dmLinetypeTable Linetypes() { return BND_File3dmLinetypeTable(m_model); }
   BND_File3dmBitmapTable Bitmaps() { return BND_File3dmBitmapTable(m_model); }
   BND_File3dmLayerTable Layers() { return BND_File3dmLayerTable(m_model); }
   BND_File3dmGroupTable AllGroups() { return BND_File3dmGroupTable(m_model); }

--- a/src/bindings/bnd_linetype.cpp
+++ b/src/bindings/bnd_linetype.cpp
@@ -1,0 +1,149 @@
+#include "bindings.h"
+
+
+#if defined(ON_PYTHON_COMPILE)
+
+BND_LinetypeSegment ON_LinetypeSegment_to_Binding(const ON_LinetypeSegment& segment)
+{
+  return pybind11::make_tuple(segment.m_length, segment.m_seg_type);
+}
+
+ON_LinetypeSegment Binding_to_ON_LinetypeSegment(const BND_LinetypeSegment& segment)
+{
+  double length = segment[0].cast<double>();
+  ON_LinetypeSegment::eSegType type = segment[1].cast<ON_LinetypeSegment::eSegType>();
+  return ON_LinetypeSegment(length, type);
+}
+
+#endif
+
+#if defined(ON_WASM_COMPILE)
+
+BND_LinetypeSegment ON_LinetypeSegment_to_Binding(const ON_LinetypeSegment& segment)
+{
+  emscripten::val v(emscripten::val::object());
+  v.set("length", emscripten::val(segment.m_length));
+  v.set("type", emscripten::val(segment.m_seg_type));
+  return v;
+}
+
+ON_LinetypeSegment Binding_to_ON_LinetypeSegment(const BND_LinetypeSegment& segment)
+{
+  double length = segment["length"].as<double>();
+  ON_LinetypeSegment::eSegType type = segment["type"].as<ON_LinetypeSegment::eSegType>();
+  return ON_LinetypeSegment(length, type);
+}
+
+#endif
+
+
+BND_Linetype::BND_Linetype()
+{
+  SetTrackedPointer(new ON_Linetype(), nullptr);
+}
+
+BND_Linetype::BND_Linetype(const ON_Linetype &existing)
+{
+  SetTrackedPointer(new ON_Linetype(existing), nullptr);
+}
+
+BND_Linetype::BND_Linetype(ON_Linetype* linetype, const ON_ModelComponentReference* compref)
+{
+  SetTrackedPointer(linetype, compref);
+}
+
+void BND_Linetype::SetTrackedPointer(ON_Linetype* linetype, const ON_ModelComponentReference* compref)
+{
+  m_linetype = linetype;
+  BND_ModelComponent::SetTrackedPointer(linetype, compref);
+}
+
+
+#if defined(ON_PYTHON_COMPILE)
+namespace py = pybind11;
+
+BND_LinetypeSegment BND_LinetypeSegmentIterator::next()
+{
+  if (m_index >= m_linetype->SegmentCount())
+  {
+    throw py::stop_iteration();
+  }
+  return ON_LinetypeSegment_to_Binding(m_linetype->Segment(m_index++));
+}
+
+void initLinetypeBindings(pybind11::module& m)
+{
+  py::enum_<ON_LinetypeSegment::eSegType>(m, "LinetypeSegmentType")
+    .value("Unset", ON_LinetypeSegment::eSegType::Unset)
+    .value("Line", ON_LinetypeSegment::eSegType::stLine)
+    .value("Space", ON_LinetypeSegment::eSegType::stSpace)
+    ;
+
+  py::class_<BND_LinetypeSegmentIterator>(m, "__LinetypeSegmentIterator")
+    .def("__iter__", &BND_LinetypeSegmentIterator::iter)
+    .def("__next__", &BND_LinetypeSegmentIterator::next)
+    ;
+
+  py::class_<BND_LinetypeSegmentList>(m, "LinetypeSegmentList")
+    .def(py::init<>())
+    .def("__len__", &BND_LinetypeSegmentList::Count)
+    .def("__getitem__", &BND_LinetypeSegmentList::Get)
+    .def("__setitem__", &BND_LinetypeSegmentList::Set)
+    .def("__delitem__", &BND_LinetypeSegmentList::Remove)
+    .def("__iter__", &BND_LinetypeSegmentList::Iterator)
+    .def("Append", &BND_LinetypeSegmentList::Append, py::arg("segment"))
+    .def("Clear", &BND_LinetypeSegmentList::Clear)
+    ;
+
+  py::class_<BND_Linetype, BND_ModelComponent>(m, "Linetype")
+    .def(py::init<>())
+    .def_property("Name", &BND_Linetype::GetName, &BND_Linetype::SetName)
+    .def_property_readonly("Index", &BND_Linetype::GetIndex)
+    .def_property_readonly("PatternLength", &BND_Linetype::PatternLength)
+    .def_property("Segments", &BND_Linetype::GetSegments, &BND_Linetype::SetSegments)
+    .def_property_readonly_static("Border", &BND_Linetype::Border)
+    .def_property_readonly_static("ByLayer", &BND_Linetype::ByLayer)
+    .def_property_readonly_static("ByParent", &BND_Linetype::ByParent)
+    .def_property_readonly_static("Center", &BND_Linetype::Center)
+    .def_property_readonly_static("Continuous", &BND_Linetype::Continuous)
+    .def_property_readonly_static("DashDot", &BND_Linetype::DashDot)
+    .def_property_readonly_static("Dashed", &BND_Linetype::Dashed)
+    .def_property_readonly_static("Dots", &BND_Linetype::Dots)
+    .def_property_readonly_static("Hidden", &BND_Linetype::Hidden)
+    ;
+}
+#endif
+
+#if defined(ON_WASM_COMPILE)
+using namespace emscripten;
+
+void initLinetypeBindings(void*)
+{
+  class_<BND_LinetypeSegmentList>("LinetypeSegmentList")
+    .constructor<>()
+    .property("count", &BND_LinetypeSegmentList::Count)
+    .function("get", &BND_LinetypeSegmentList::Get)
+    .function("set", &BND_LinetypeSegmentList::Set)
+    .function("append", &BND_LinetypeSegmentList::Append)
+    .function("remove", &BND_LinetypeSegmentList::Remove)
+    .function("clear", &BND_LinetypeSegmentList::Clear)
+    ;
+
+  class_<BND_Linetype, base<BND_ModelComponent>>("Linetype")
+    .constructor<>()
+    .property("name", &BND_Linetype::GetName, &BND_Linetype::SetName)
+    .property("index", &BND_Linetype::GetIndex)
+    .property("patternLength", &BND_Linetype::PatternLength)
+    .property("segments", &BND_Linetype::GetSegments, &BND_Linetype::SetSegments)
+    .class_property("border", &BND_Linetype::Border)
+    .class_property("byLayer", &BND_Linetype::ByLayer)
+    .class_property("byParent", &BND_Linetype::ByParent)
+    .class_property("center", &BND_Linetype::Center)
+    .class_property("continuous", &BND_Linetype::Continuous)
+    .class_property("dashdot", &BND_Linetype::DashDot)
+    .class_property("dashed", &BND_Linetype::Dashed)
+    .class_property("dots", &BND_Linetype::Dots)
+    .class_property("hidden", &BND_Linetype::Hidden)
+    ;
+}
+#endif

--- a/src/bindings/bnd_linetype.h
+++ b/src/bindings/bnd_linetype.h
@@ -1,0 +1,85 @@
+#include "bindings.h"
+
+#pragma once
+
+#if defined(ON_PYTHON_COMPILE)
+typedef pybind11::tuple BND_LinetypeSegment;
+void initLinetypeBindings(pybind11::module& m);
+#else
+typedef emscripten::val BND_LinetypeSegment;
+void initLinetypeBindings(void* m);
+#endif
+
+BND_LinetypeSegment ON_LinetypeSegment_to_Binding(const ON_LinetypeSegment& segment);
+ON_LinetypeSegment Binding_to_ON_LinetypeSegment(const BND_LinetypeSegment& segment);
+
+#if defined(ON_PYTHON_COMPILE)
+class BND_LinetypeSegmentIterator
+{
+  ON_Linetype* m_linetype = nullptr;
+  int m_index = 0;
+public:
+  BND_LinetypeSegmentIterator(ON_Linetype* linetype) : m_linetype(linetype) {}
+  BND_LinetypeSegmentIterator iter() { return BND_LinetypeSegmentIterator(m_linetype); }
+  BND_LinetypeSegment next();
+};
+#endif
+
+class BND_LinetypeSegmentList
+{
+  ON_Linetype* m_linetype = nullptr;
+public:
+  BND_LinetypeSegmentList() : m_linetype(new ON_Linetype()) {}
+  BND_LinetypeSegmentList(ON_Linetype* linetype) : m_linetype(linetype) {}
+
+  int Count() const { return m_linetype->SegmentCount(); }
+  BND_LinetypeSegment Get(int index) const { return ON_LinetypeSegment_to_Binding(m_linetype->Segment(index)); }
+  int Append(BND_LinetypeSegment segment) { return m_linetype->AppendSegment(Binding_to_ON_LinetypeSegment(segment)); }
+  bool Set(int index, BND_LinetypeSegment segment) { return m_linetype->SetSegment(index, Binding_to_ON_LinetypeSegment(segment)); }
+  bool Remove(int index) { return m_linetype->RemoveSegment(index); }
+  bool Clear() { return m_linetype->ClearPattern(); }
+  BND_LinetypeSegmentIterator Iterator() { return BND_LinetypeSegmentIterator(m_linetype); }
+
+  friend class BND_Linetype;
+};
+
+class BND_Linetype : public BND_ModelComponent
+{
+public:
+  ON_Linetype* m_linetype = nullptr;
+protected:
+  void SetTrackedPointer(ON_Linetype* linetype, const ON_ModelComponentReference* compref);
+public:
+  BND_Linetype();
+  BND_Linetype(const ON_Linetype&);
+  BND_Linetype(ON_Linetype* linetype, const ON_ModelComponentReference* compref);
+
+  std::wstring GetName() const { return std::wstring(m_linetype->NameAsPointer()); }
+  void SetName(const std::wstring& name) { m_linetype->SetName(name.c_str()); }
+  int GetIndex() const { return m_linetype->Index(); }
+  double PatternLength() const { return m_linetype->PatternLength(); }
+  BND_LinetypeSegmentList GetSegments() const { return BND_LinetypeSegmentList(m_linetype); }
+  bool SetSegments(BND_LinetypeSegmentList segments) { return m_linetype->SetSegments(segments.m_linetype->Segments()); }
+
+#if defined(ON_PYTHON_COMPILE)
+  static BND_Linetype* Border(pybind11::object /*self*/) { return new BND_Linetype(ON_Linetype::Border); }
+  static BND_Linetype* ByLayer(pybind11::object /*self*/) { return new BND_Linetype(ON_Linetype::ByLayer); }
+  static BND_Linetype* ByParent(pybind11::object /*self*/) { return new BND_Linetype(ON_Linetype::ByParent); }
+  static BND_Linetype* Center(pybind11::object /*self*/) { return new BND_Linetype(ON_Linetype::Center); }
+  static BND_Linetype* Continuous(pybind11::object /*self*/) { return new BND_Linetype(ON_Linetype::Continuous); }
+  static BND_Linetype* DashDot(pybind11::object /*self*/) { return new BND_Linetype(ON_Linetype::DashDot); }
+  static BND_Linetype* Dashed(pybind11::object /*self*/) { return new BND_Linetype(ON_Linetype::Dashed); }
+  static BND_Linetype* Dots(pybind11::object /*self*/) { return new BND_Linetype(ON_Linetype::Dots); }
+  static BND_Linetype* Hidden(pybind11::object /*self*/) { return new BND_Linetype(ON_Linetype::Hidden); }
+#else
+  static BND_Linetype* Border() { return new BND_Linetype(ON_Linetype::Border); }
+  static BND_Linetype* ByLayer() { return new BND_Linetype(ON_Linetype::ByLayer); }
+  static BND_Linetype* ByParent() { return new BND_Linetype(ON_Linetype::ByParent); }
+  static BND_Linetype* Center() { return new BND_Linetype(ON_Linetype::Center); }
+  static BND_Linetype* Continuous() { return new BND_Linetype(ON_Linetype::Continuous); }
+  static BND_Linetype* DashDot() { return new BND_Linetype(ON_Linetype::DashDot); }
+  static BND_Linetype* Dashed() { return new BND_Linetype(ON_Linetype::Dashed); }
+  static BND_Linetype* Dots() { return new BND_Linetype(ON_Linetype::Dots); }
+  static BND_Linetype* Hidden() { return new BND_Linetype(ON_Linetype::Hidden); }
+#endif
+};


### PR DESCRIPTION
This pull request enables inspection and manipulation of line types in an openNURBS model by adding `Linetype` and `File3dmLinetypeTable` classes to the rhino3dm Python module. Comments and criticism are welcome as I hope to make several more contributions over the next few months.

This code has not been tested in JavaScript due to difficulties setting up the emscripten environment.