### PR TITLE
Add .editorconfig

### DIFF
--- a/src/bindings/.editorconfig
+++ b/src/bindings/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome:
+# http://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This pull request adds an `.editorconfig` file to the `src/bindings` folder so newcomers like me will be less likely to ignorantly plow through the project's indentation convention in the future.