### PR TITLE
Additional File3dm properties

### DIFF
--- a/src/bindings/bindings.cpp
+++ b/src/bindings/bindings.cpp
@@ -91,3 +91,27 @@ BND_TUPLE NullTuple()
 #endif
 }
 
+BND_DateTime CreateDateTime(struct tm t)
+{
+#if defined(ON_PYTHON_COMPILE)
+  if (!PyDateTimeAPI) {
+    PyDateTime_IMPORT;
+  }
+  return PyDateTime_FromDateAndTime(t.tm_year + 1900,
+                                    t.tm_mon + 1,
+                                    t.tm_mday,
+                                    t.tm_hour,
+                                    t.tm_min,
+                                    t.tm_sec,
+                                    0);
+#else
+  emscripten::val Date = emscripten::val::global("Date");
+  return Date.new_(t.tm_year + 1900,
+                   t.tm_mon,
+                   t.tm_mday,
+                   t.tm_hour,
+                   t.tm_min,
+                   t.tm_sec,
+                   0);
+#endif
+}

--- a/src/bindings/bindings.h
+++ b/src/bindings/bindings.h
@@ -14,6 +14,7 @@
 #if defined(ON_PYTHON_COMPILE)
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include "datetime.h"
 #pragma comment(lib, "rpcrt4.lib")
 #pragma comment(lib, "shlwapi.lib")
 #endif
@@ -27,11 +28,13 @@
 typedef pybind11::dict BND_DICT;
 typedef pybind11::tuple BND_Color;
 typedef pybind11::tuple BND_TUPLE;
+typedef pybind11::handle BND_DateTime;
 #endif
 #if defined(ON_WASM_COMPILE)
 typedef emscripten::val BND_DICT;
 typedef emscripten::val BND_Color;
 typedef emscripten::val BND_TUPLE;
+typedef emscripten::val BND_DateTime;
 #endif
 
 BND_TUPLE CreateTuple(int count);
@@ -45,6 +48,8 @@ void SetTuple(BND_TUPLE& tuple, int index, const T& value)
   tuple.set(index, value);
 #endif
 }
+
+BND_DateTime CreateDateTime(struct tm t);
 
 #include "bnd_color.h"
 #include "bnd_file_utilities.h"

--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -372,6 +372,30 @@ std::wstring BND_ONXModel::GetLastEditedBy() const
   return std::wstring(s);
 }
 
+#if defined(ON_PYTHON_COMPILE)
+pybind11::handle toPyDateTime(struct tm t)
+{
+  if (!PyDateTimeAPI) {
+    PyDateTime_IMPORT;
+  }
+  return PyDateTime_FromDateAndTime(t.tm_year + 1900,
+                                    t.tm_mon + 1,
+                                    t.tm_mday,
+                                    t.tm_hour,
+                                    t.tm_min,
+                                    t.tm_sec,
+                                    0);
+}
+pybind11::handle BND_ONXModel::GetCreated() const
+{
+  return toPyDateTime(m_model->m_properties.m_RevisionHistory.m_create_time);
+}
+pybind11::handle BND_ONXModel::GetLastEdited() const
+{
+  return toPyDateTime(m_model->m_properties.m_RevisionHistory.m_last_edit_time);
+}
+#endif
+
 RH_C_FUNCTION int ONX_Model_GetRevision(const ONX_Model* pConstModel)
 {
   int rc = 0;
@@ -1473,7 +1497,9 @@ void initExtensionsBindings(pybind11::module& m)
     .def_property("ApplicationUrl", &BND_ONXModel::GetApplicationUrl, &BND_ONXModel::SetApplicationUrl)
     .def_property("ApplicationDetails", &BND_ONXModel::GetApplicationDetails, &BND_ONXModel::SetApplicationDetails)
     .def_property_readonly("ArchiveVersion", &BND_ONXModel::GetArchiveVersion)
+    .def_property_readonly("Created", &BND_ONXModel::GetCreated)
     .def_property_readonly("CreatedBy", &BND_ONXModel::GetCreatedBy)
+    .def_property_readonly("LastEdited", &BND_ONXModel::GetLastEdited)
     .def_property_readonly("LastEditedBy", &BND_ONXModel::GetLastEditedBy)
     .def_property("Revision", &BND_ONXModel::GetRevision, &BND_ONXModel::SetRevision)
     .def_property_readonly("Settings", &BND_ONXModel::Settings)

--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -371,30 +371,14 @@ std::wstring BND_ONXModel::GetLastEditedBy() const
   ONX_Model_GetString(m_model.get(), idxLastCreatedBy, &s);
   return std::wstring(s);
 }
-
-#if defined(ON_PYTHON_COMPILE)
-pybind11::handle toPyDateTime(struct tm t)
+BND_DateTime BND_ONXModel::GetCreated() const
 {
-  if (!PyDateTimeAPI) {
-    PyDateTime_IMPORT;
-  }
-  return PyDateTime_FromDateAndTime(t.tm_year + 1900,
-                                    t.tm_mon + 1,
-                                    t.tm_mday,
-                                    t.tm_hour,
-                                    t.tm_min,
-                                    t.tm_sec,
-                                    0);
+  return CreateDateTime(m_model->m_properties.m_RevisionHistory.m_create_time);
 }
-pybind11::handle BND_ONXModel::GetCreated() const
+BND_DateTime BND_ONXModel::GetLastEdited() const
 {
-  return toPyDateTime(m_model->m_properties.m_RevisionHistory.m_create_time);
+  return CreateDateTime(m_model->m_properties.m_RevisionHistory.m_last_edit_time);
 }
-pybind11::handle BND_ONXModel::GetLastEdited() const
-{
-  return toPyDateTime(m_model->m_properties.m_RevisionHistory.m_last_edit_time);
-}
-#endif
 
 RH_C_FUNCTION int ONX_Model_GetRevision(const ONX_Model* pConstModel)
 {
@@ -1653,7 +1637,10 @@ void initExtensionsBindings(void*)
     .property("applicationName", &BND_ONXModel::GetApplicationName, &BND_ONXModel::SetApplicationName)
     .property("applicationUrl", &BND_ONXModel::GetApplicationUrl, &BND_ONXModel::SetApplicationUrl)
     .property("applicationDetails", &BND_ONXModel::GetApplicationDetails, &BND_ONXModel::SetApplicationDetails)
+    .property("archiveVersion", &BND_ONXModel::GetArchiveVersion)
+    .property("created", &BND_ONXModel::GetCreated)
     .property("createdBy", &BND_ONXModel::GetCreatedBy)
+    .property("lastEdited", &BND_ONXModel::GetLastEdited)
     .property("lastEditedBy", &BND_ONXModel::GetLastEditedBy)
     .property("revision", &BND_ONXModel::GetRevision, &BND_ONXModel::SetRevision)
     .function("settings", &BND_ONXModel::Settings)

--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -355,6 +355,10 @@ void BND_ONXModel::SetApplicationDetails(std::wstring s)
 {
   ONX_Model_SetString(m_model.get(), idxApplicationDetails, s.c_str());
 }
+int BND_ONXModel::GetArchiveVersion() const
+{
+  return m_model->m_3dm_file_version;
+}
 std::wstring BND_ONXModel::GetCreatedBy() const
 {
   ON_wString s;
@@ -1468,6 +1472,7 @@ void initExtensionsBindings(pybind11::module& m)
     .def_property("ApplicationName", &BND_ONXModel::GetApplicationName, &BND_ONXModel::SetApplicationName)
     .def_property("ApplicationUrl", &BND_ONXModel::GetApplicationUrl, &BND_ONXModel::SetApplicationUrl)
     .def_property("ApplicationDetails", &BND_ONXModel::GetApplicationDetails, &BND_ONXModel::SetApplicationDetails)
+    .def_property_readonly("ArchiveVersion", &BND_ONXModel::GetArchiveVersion)
     .def_property_readonly("CreatedBy", &BND_ONXModel::GetCreatedBy)
     .def_property_readonly("LastEditedBy", &BND_ONXModel::GetLastEditedBy)
     .def_property("Revision", &BND_ONXModel::GetRevision, &BND_ONXModel::SetRevision)

--- a/src/bindings/bnd_extensions.h
+++ b/src/bindings/bnd_extensions.h
@@ -1,4 +1,5 @@
 #include "bindings.h"
+#include "datetime.h"
 
 #pragma once
 
@@ -271,8 +272,10 @@ public:
   int GetArchiveVersion() const;
   std::wstring GetCreatedBy() const;
   std::wstring GetLastEditedBy() const;
-  //public DateTime Created | get;
-  //public DateTime LastEdited | get;
+  #if defined(ON_PYTHON_COMPILE)
+  pybind11::handle GetCreated() const;
+  pybind11::handle GetLastEdited() const;
+  #endif
   int GetRevision() const;
   void SetRevision(int r);
   BND_File3dmSettings Settings() { return BND_File3dmSettings(m_model); }

--- a/src/bindings/bnd_extensions.h
+++ b/src/bindings/bnd_extensions.h
@@ -1,5 +1,4 @@
 #include "bindings.h"
-#include "datetime.h"
 
 #pragma once
 
@@ -272,10 +271,8 @@ public:
   int GetArchiveVersion() const;
   std::wstring GetCreatedBy() const;
   std::wstring GetLastEditedBy() const;
-  #if defined(ON_PYTHON_COMPILE)
-  pybind11::handle GetCreated() const;
-  pybind11::handle GetLastEdited() const;
-  #endif
+  BND_DateTime GetCreated() const;
+  BND_DateTime GetLastEdited() const;
   int GetRevision() const;
   void SetRevision(int r);
   BND_File3dmSettings Settings() { return BND_File3dmSettings(m_model); }

--- a/src/bindings/bnd_extensions.h
+++ b/src/bindings/bnd_extensions.h
@@ -268,6 +268,7 @@ public:
   void SetApplicationUrl(std::wstring url);
   std::wstring GetApplicationDetails() const;
   void SetApplicationDetails(std::wstring details);
+  int GetArchiveVersion() const;
   std::wstring GetCreatedBy() const;
   std::wstring GetLastEditedBy() const;
   //public DateTime Created | get;


### PR DESCRIPTION
This pull request adds implementations of the following read-only properties of `File3dm` for both Python and Javascript:
- [`ArchiveVersion`](https://developer.rhino3d.com/api/rhinocommon/rhino.fileio.file3dm/archiveversion)
- [`Created`](https://developer.rhino3d.com/api/rhinocommon/rhino.fileio.file3dm/created)
- [`LastEdited`](https://developer.rhino3d.com/api/rhinocommon/rhino.fileio.file3dm/lastedited)