### PR TITLE
Wrap annotation-related API

### DIFF
--- a/script/bootstrap.py
+++ b/script/bootstrap.py
@@ -77,8 +77,7 @@ def print_error_message(error_message):
     if xcode_logging:
         print(error_prefix + error_message)
     else:
-        print(bcolors.BOLD + bcolors.FAIL + error_prefix.upper() + bcolors.ENDC + bcolors.FAIL + error_message +
-              bcolors.ENDC)
+        print(f"{bcolors.BOLD}{bcolors.FAIL}{error_prefix.upper()}{bcolors.ENDC}{bcolors.FAIL}{error_message}{bcolors.ENDC}")
 
 
 def print_ok_message(ok_message):

--- a/src/bindings/bnd_annotationbase.cpp
+++ b/src/bindings/bnd_annotationbase.cpp
@@ -1,5 +1,8 @@
 #include "bindings.h"
 
+BND_AnnotationBase::BND_AnnotationBase()
+{
+}
 
 BND_AnnotationBase::BND_AnnotationBase(ON_Annotation* annotation, const ON_ModelComponentReference* compref)
 {
@@ -10,6 +13,23 @@ void BND_AnnotationBase::SetTrackedPointer(ON_Annotation* annotation, const ON_M
 {
   m_annotation = annotation;
   BND_GeometryBase::SetTrackedPointer(annotation, compref);
+}
+
+ON::AnnotationType BND_AnnotationBase::AnnotationType() const
+{
+  return m_annotation->Type();
+}
+
+/*
+double BND_AnnotationBase::TextHeight() const
+{
+  return m_annotation->TextHeight();
+}
+*/
+
+BND_Plane BND_AnnotationBase::Plane() const
+{
+  return BND_Plane::FromOnPlane(m_annotation->Plane());
 }
 
 std::wstring BND_AnnotationBase::RichText() const
@@ -36,7 +56,61 @@ std::wstring BND_AnnotationBase::PlainTextWithFields() const
   return rc;
 }
 
+bool BND_AnnotationBase::TextIsWrapped() const
+{
+  const ON_TextContent* text = m_annotation->Text();
+  if(nullptr != text)
+  {
+    return text->TextIsWrapped();
+  }
+  return false;
+}
 
+void BND_AnnotationBase::SetTextIsWrapped(bool wrapped)
+{
+  ON_TextContent* text = m_annotation->Text();
+  if(nullptr != text)
+  {
+    text->SetTextIsWrapped(wrapped);
+  }
+}
+
+void BND_AnnotationBase::WrapText(double wrapwidth)
+{
+  ON_TextContent* text = m_annotation->Text();
+  if(nullptr != text)
+  {
+    text->WrapText(wrapwidth);
+  }
+}
+
+/*
+BND_DimensionStyle BND_AnnotationBase::DimensionStyle()
+{
+  ON_UUID dimstyleid = m_annotation->DimensionStyleId();
+
+  //const ON_DimStyle &ds = m_annotation->DimensionStyle();
+  ON_ModelComponentReference compref = m_model->DimensionStyleFromIndex(index);
+  const ON_ModelComponent* model_component = compref.ModelComponent();
+  ON_DimStyle* modeldimstyle = const_cast<ON_DimStyle*>(ON_DimStyle::Cast(model_component));
+  if (modeldimstyle)
+    return new BND_DimensionStyle(modeldimstyle, &compref);
+
+#if defined(ON_PYTHON_COMPILE)
+  throw pybind11::index_error();
+#else
+  return nullptr;
+#endif
+}
+*/
+
+BND_UUID BND_AnnotationBase::DimensionStyleId() const
+{
+  ON_UUID dimstyleid = m_annotation->DimensionStyleId();
+  return ON_UUID_to_Binding(dimstyleid);
+}
+
+/*********/
 
 BND_TextDot::BND_TextDot(ON_TextDot* dot, const ON_ModelComponentReference* compref)
 {
@@ -54,15 +128,547 @@ void BND_TextDot::SetTrackedPointer(ON_TextDot* dot, const ON_ModelComponentRefe
   BND_GeometryBase::SetTrackedPointer(dot, compref);
 }
 
+/*********/
+
+BND_Text::BND_Text(ON_Text* text, const ON_ModelComponentReference* compref)
+{
+  SetTrackedPointer(text, compref);
+}
+
+
+void BND_Text::SetTrackedPointer(ON_Text* text, const ON_ModelComponentReference* compref)
+{
+  m_text = text;
+  BND_AnnotationBase::SetTrackedPointer(text, compref);
+}
+
+/*********/
+
+BND_Leader::BND_Leader(ON_Leader* leader, const ON_ModelComponentReference* compref)
+{
+  SetTrackedPointer(leader, compref);
+}
+
+
+void BND_Leader::SetTrackedPointer(ON_Leader* leader, const ON_ModelComponentReference* compref)
+{
+  m_leader= leader;
+  BND_AnnotationBase::SetTrackedPointer(leader, compref);
+}
+
+#if defined(ON_PYTHON_COMPILE)
+std::vector<ON_3dPoint> BND_Leader::GetPoints() const
+#else
+emscripten::val BND_Leader::GetPoints() const
+#endif
+{
+#if defined(ON_PYTHON_COMPILE)
+  std::vector<ON_3dPoint> rc;
+#else
+  emscripten::val rc = emscripten::val::array();
+#endif
+  const ON_2dPointArray& points = m_leader->Points2d();
+  for (int i = 0; i < points.Count(); i++)
+  {
+    ON_3dPoint pt;
+    if(m_leader->Point3d(i, pt)) {
+#if defined(ON_PYTHON_COMPILE)
+      rc.push_back(pt);
+#else
+      rc.call<void>("push", PointToDict(pt));
+#endif
+    }
+  }
+  return rc;
+}
+
+ON_2dPoint BND_Leader::GetTextPoint2d(const BND_DimensionStyle& dimstyle, double leaderscale) const
+{
+  ON_2dPoint pt;
+  if(m_leader->GetTextPoint2d(dimstyle.m_dimstyle, leaderscale, pt))
+    return pt;
+  return ON_2dPoint::UnsetPoint;
+}
+
+/*********/
+
+BND_Dimension::BND_Dimension()
+{
+}
+
+BND_Dimension::BND_Dimension(ON_Dimension* dimension, const ON_ModelComponentReference* compref)
+{
+  SetTrackedPointer(dimension, compref);
+}
+
+void BND_Dimension::SetTrackedPointer(ON_Dimension* dimension, const ON_ModelComponentReference* compref)
+{
+  m_dimension = dimension;
+  BND_AnnotationBase::SetTrackedPointer(dimension, compref);
+}
+/*********/
+
+BND_DimLinear::BND_DimLinear(ON_DimLinear* dimLinear, const ON_ModelComponentReference* compref)
+{
+  SetTrackedPointer(dimLinear, compref);
+}
+
+void BND_DimLinear::SetTrackedPointer(ON_DimLinear* dimLinear, const ON_ModelComponentReference* compref)
+{
+  m_dimLinear = dimLinear;
+  BND_Dimension::SetTrackedPointer(dimLinear, compref);
+}
+
+/*
+
+#if defined(ON_PYTHON_COMPILE)
+  BND_DICT d;
+#else
+  emscripten::val d(emscripten::val::object());
+#endif
+#if defined(ON_PYTHON_COMPILE)
+  d["radius"] = Radius();
+  d["plane"] = PlaneToDict(m_circle.plane);
+#else
+  d.set("radius", emscripten::val(Radius()));
+  d.set("plane", emscripten::val(PlaneToDict(m_circle.plane)));
+#endif
+*/
+
+BND_DICT BND_DimLinear::GetPoints() const
+{
+  ON_3dPoint defpt1;
+  ON_3dPoint defpt2;
+  ON_3dPoint arrowpt1;
+  ON_3dPoint arrowpt2;
+  ON_3dPoint dimline;
+  ON_3dPoint textpt;
+  if(m_dimLinear->Get3dPoints(&defpt1, &defpt2, &arrowpt1, &arrowpt2, &dimline, &textpt))
+  {
+#if defined(ON_PYTHON_COMPILE)
+    BND_DICT d;
+#else
+    emscripten::val d(emscripten::val::object());
+#endif
+#if defined(ON_PYTHON_COMPILE)
+    d["defpt1"] = defpt1;
+    d["defpt2"] = defpt2;
+    d["arrowpt1"] = arrowpt1;
+    d["arrowpt2"] = arrowpt2;
+    d["dimline"] = dimline;
+    d["textpt"] = textpt;
+#else
+    d.set("defpt1", PointToDict(defpt1));
+    d.set("defpt2", PointToDict(defpt2));
+    d.set("arrowpt1", PointToDict(arrowpt1));
+    d.set("arrowpt2", PointToDict(arrowpt2));
+    d.set("dimline", PointToDict(dimline));
+    d.set("textpt", PointToDict(textpt));
+#endif
+    return d;
+  }
+#if defined(ON_PYTHON_COMPILE)
+  throw pybind11::value_error("Failed to get DimLinear points");
+#else
+  return emscripten::val::null();
+#endif
+}
+
+BND_DICT BND_DimLinear::GetDisplayLines(const BND_DimensionStyle& dimstyle)
+{
+#if defined(ON_PYTHON_COMPILE)
+    BND_DICT d;
+#else
+    emscripten::val d(emscripten::val::object());
+#endif
+  std::vector<ON_Line> rc;
+  std::vector<ON_3dPoint> text_points;
+  ON_3dPoint text_rect[4];
+  ON_Line lines[4];
+  bool isline[4];
+  if (m_dimLinear->GetDisplayLines(nullptr, dimstyle.m_dimstyle, 1.0, text_rect, lines, isline, 4))
+  {
+    for(int i = 0; i < 4; i++)
+    {
+      if(isline[i])
+        rc.push_back(lines[i]);
+    }
+    for(int i = 0; i < 4; i++)
+    {
+        text_points.push_back(text_rect[i]);
+    }
+
+#if defined(ON_PYTHON_COMPILE)
+    d["lines"] = rc;
+    d["text_rect"] = text_points;
+#else
+    d.set("lines", emscripten::val(rc));
+    d.set("text_rect", emscripten::val(text_points));
+#endif
+  }
+
+  return d;
+}
+/*********/
+
+BND_DimAngular::BND_DimAngular(ON_DimAngular* dimAngular, const ON_ModelComponentReference* compref)
+{
+  SetTrackedPointer(dimAngular, compref);
+}
+
+void BND_DimAngular::SetTrackedPointer(ON_DimAngular* dimAngular, const ON_ModelComponentReference* compref)
+{
+  m_dimAngular = dimAngular;
+  BND_Dimension::SetTrackedPointer(dimAngular, compref);
+}
+
+double BND_DimAngular::Radius() const
+{
+  return m_dimAngular->Radius();
+}
+
+double BND_DimAngular::Measurement() const
+{
+  return m_dimAngular->Measurement();
+}
+
+BND_DICT BND_DimAngular::GetPoints() const
+{
+  ON_3dPoint centerpt;
+  ON_3dPoint defpt1;
+  ON_3dPoint defpt2;
+  ON_3dPoint arrowpt1;
+  ON_3dPoint arrowpt2;
+  ON_3dPoint dimlinept;
+  ON_3dPoint textpt;
+  if(m_dimAngular->Get3dPoints(&centerpt, &defpt1, &defpt2, &arrowpt1, &arrowpt2, &dimlinept, &textpt))
+  {
+#if defined(ON_PYTHON_COMPILE)
+    BND_DICT d;
+#else
+    emscripten::val d(emscripten::val::object());
+#endif
+
+#if defined(ON_PYTHON_COMPILE)
+    d["centerpt"] = centerpt;
+    d["defpt1"] = defpt1;
+    d["defpt2"] = defpt2;
+    d["arrowpt1"] = arrowpt1;
+    d["arrowpt2"] = arrowpt2;
+    d["dimlinept"] = dimlinept;
+    d["textpt"] = textpt;
+#else
+    d.set("centerpt", PointToDict(centerpt));
+    d.set("defpt1", PointToDict(defpt1));
+    d.set("defpt2", PointToDict(defpt2));
+    d.set("arrowpt1", PointToDict(arrowpt1));
+    d.set("arrowpt2", PointToDict(arrowpt2));
+    d.set("dimlinept", PointToDict(dimlinept));
+    d.set("textpt", PointToDict(textpt));
+#endif
+    return d;
+  }
+#if defined(ON_PYTHON_COMPILE)
+  throw pybind11::value_error("Failed to get DimAngular points");
+#else
+  return emscripten::val::null();
+#endif
+}
+
+BND_DICT BND_DimAngular::GetDisplayLines(const BND_DimensionStyle& dimstyle)
+{
+#if defined(ON_PYTHON_COMPILE)
+    BND_DICT d;
+#else
+    emscripten::val d(emscripten::val::object());
+#endif
+  std::vector<ON_Line> linevec;
+  std::vector<BND_Arc> arcvec;
+  std::vector<ON_3dPoint> text_points;
+  ON_3dPoint text_rect[4];
+  ON_Line lines[2];
+  bool isline[2];
+  ON_Arc arcs[2];
+  bool isarc[2];
+  if (m_dimAngular->GetDisplayLines(nullptr, dimstyle.m_dimstyle, 1.0, text_rect, lines, isline, arcs, isarc, 2, 2))
+  {
+    for(int i = 0; i < 2; i++)
+    {
+      if(isline[i])
+        linevec.push_back(lines[i]);
+    }
+    for(int i = 0; i < 2; i++)
+    {
+      if(isarc[i])
+        arcvec.push_back(BND_Arc(arcs[i]));
+    }
+    for(int i = 0; i < 4; i++)
+    {
+        text_points.push_back(text_rect[i]);
+    }
+
+#if defined(ON_PYTHON_COMPILE)
+    d["lines"] = linevec;
+    d["arcs"] = arcvec;
+    d["text_rect"] = text_points;
+#else
+    d.set("lines", emscripten::val(linevec));
+    d.set("arcs", emscripten::val(arcvec));
+    d.set("text_rect", emscripten::val(text_points));
+#endif
+  }
+
+  return d;
+}
+
+/*********/
+
+BND_DimRadial::BND_DimRadial(ON_DimRadial* dimRadial, const ON_ModelComponentReference* compref)
+{
+  SetTrackedPointer(dimRadial, compref);
+}
+
+void BND_DimRadial::SetTrackedPointer(ON_DimRadial* dimRadial, const ON_ModelComponentReference* compref)
+{
+  m_dimRadial = dimRadial;
+  BND_Dimension::SetTrackedPointer(dimRadial, compref);
+}
+
+BND_DICT BND_DimRadial::GetPoints() const
+{
+  ON_3dPoint centerpt;
+  ON_3dPoint radiuspt;
+  ON_3dPoint dimlinept;
+  ON_3dPoint kneept;
+  if(m_dimRadial->Get3dPoints(&centerpt, &radiuspt, &dimlinept, &kneept))
+  {
+#if defined(ON_PYTHON_COMPILE)
+    BND_DICT d;
+#else
+    emscripten::val d(emscripten::val::object());
+#endif
+
+#if defined(ON_PYTHON_COMPILE)
+    d["centerpt"] = centerpt;
+    d["radiuspt"] = radiuspt;
+    d["dimlinept"] = dimlinept;
+    d["kneept"] = kneept;
+#else
+    d.set("centerpt", PointToDict(centerpt));
+    d.set("radiuspt", PointToDict(radiuspt));
+    d.set("dimlinept", PointToDict(dimlinept));
+    d.set("kneept", PointToDict(kneept));
+#endif
+
+    return d;
+  }
+#if defined(ON_PYTHON_COMPILE)
+  throw pybind11::value_error("Failed to get DimRadial points");
+#else
+  return emscripten::val::null();
+#endif
+}
+
+BND_DICT BND_DimRadial::GetDisplayLines(const BND_DimensionStyle& dimstyle)
+{
+#if defined(ON_PYTHON_COMPILE)
+    BND_DICT d;
+#else
+    emscripten::val d(emscripten::val::object());
+#endif
+  std::vector<ON_Line> rc;
+  std::vector<ON_3dPoint> text_points;
+  ON_3dPoint text_rect[4];
+  ON_Line lines[9];
+  bool isline[9];
+  if (m_dimRadial->GetDisplayLines(dimstyle.m_dimstyle, 1.0, text_rect, lines, isline, 9))
+  {
+    for(int i = 0; i < 9; i++)
+    {
+      if(isline[i])
+        rc.push_back(lines[i]);
+    }
+    for(int i = 0; i < 4; i++)
+    {
+        text_points.push_back(text_rect[i]);
+    }
+
+#if defined(ON_PYTHON_COMPILE)
+    d["lines"] = rc;
+    d["text_rect"] = text_points;
+#else
+    d.set("lines", emscripten::val(rc));
+    d.set("text_rect", emscripten::val(text_points));
+#endif
+  }
+
+  return d;
+}
+
+/*********/
+
+BND_DimOrdinate::BND_DimOrdinate(ON_DimOrdinate* dimOrdinate, const ON_ModelComponentReference* compref)
+{
+  SetTrackedPointer(dimOrdinate, compref);
+}
+
+void BND_DimOrdinate::SetTrackedPointer(ON_DimOrdinate* dimOrdinate, const ON_ModelComponentReference* compref)
+{
+  m_dimOrdinate = dimOrdinate;
+  BND_Dimension::SetTrackedPointer(dimOrdinate, compref);
+}
+
+BND_DICT BND_DimOrdinate::GetPoints() const
+{
+  ON_3dPoint basept;
+  ON_3dPoint defpt;
+  ON_3dPoint leaderpt;
+  ON_3dPoint kinkpt1;
+  ON_3dPoint kinkpt2;
+  if(m_dimOrdinate->Get3dPoints(&basept, &defpt, &leaderpt, &kinkpt1, &kinkpt2))
+  {
+#if defined(ON_PYTHON_COMPILE)
+    BND_DICT d;
+#else
+    emscripten::val d(emscripten::val::object());
+#endif
+
+#if defined(ON_PYTHON_COMPILE)
+    d["basept"] = basept;
+    d["defpt"] = defpt;
+    d["leaderpt"] = leaderpt;
+    d["kinkpt1"] = kinkpt1;
+    d["kinkpt2"] = kinkpt2;
+#else
+    d.set("basept", PointToDict(basept));
+    d.set("defpt", PointToDict(defpt));
+    d.set("leaderpt", PointToDict(leaderpt));
+    d.set("kinkpt1", PointToDict(kinkpt1));
+    d.set("kinkpt2", PointToDict(kinkpt2));
+#endif
+
+    return d;
+  }
+#if defined(ON_PYTHON_COMPILE)
+  throw pybind11::value_error("Failed to get DimOrdinate points");
+#else
+  return emscripten::val::null();
+#endif
+}
+
+BND_DICT BND_DimOrdinate::GetDisplayLines(const BND_DimensionStyle& dimstyle)
+{
+#if defined(ON_PYTHON_COMPILE)
+    BND_DICT d;
+#else
+    emscripten::val d(emscripten::val::object());
+#endif
+  std::vector<ON_Line> rc;
+  std::vector<ON_3dPoint> text_points;
+  ON_3dPoint text_rect[4];
+  ON_Line lines[3];
+  bool isline[3];
+  if (m_dimOrdinate->GetDisplayLines(dimstyle.m_dimstyle, 1.0, text_rect, lines, isline, 3))
+  {
+    for(int i = 0; i < 3; i++)
+    {
+      if(isline[i])
+        rc.push_back(lines[i]);
+    }
+    for(int i = 0; i < 4; i++)
+    {
+        text_points.push_back(text_rect[i]);
+    }
+
+#if defined(ON_PYTHON_COMPILE)
+    d["lines"] = rc;
+    d["text_rect"] = text_points;
+#else
+    d.set("lines", emscripten::val(rc));
+    d.set("text_rect", emscripten::val(text_points));
+#endif
+  }
+
+  return d;
+}
+
+/*********/
+
+BND_Centermark::BND_Centermark(ON_Centermark* centermark, const ON_ModelComponentReference* compref)
+{
+  SetTrackedPointer(centermark, compref);
+}
+
+void BND_Centermark::SetTrackedPointer(ON_Centermark* centermark, const ON_ModelComponentReference* compref)
+{
+  m_centermark = centermark;
+  BND_Dimension::SetTrackedPointer(centermark, compref);
+}
+
+std::vector<ON_Line> BND_Centermark::GetDisplayLines(const BND_DimensionStyle& dimstyle)
+{
+  std::vector<ON_Line> rc;
+  ON_Line lines[6];
+  bool isline[6];
+  if (m_centermark->GetDisplayLines(dimstyle.m_dimstyle, 1.0, lines, isline, 6))
+  {
+    for(int i = 0; i < 6; i++)
+    {
+      if(isline[i])
+        rc.push_back(lines[i]);
+    }
+  }
+
+  return rc;
+}
 
 #if defined(ON_PYTHON_COMPILE)
 namespace py = pybind11;
 void initAnnotationBaseBindings(pybind11::module& m)
 {
   py::class_<BND_AnnotationBase, BND_GeometryBase>(m, "AnnotationBase")
+    .def_property_readonly("DimensionStyleId", &BND_AnnotationBase::DimensionStyleId)
     .def_property_readonly("RichText", &BND_AnnotationBase::RichText)
     .def_property_readonly("PlainText", &BND_AnnotationBase::PlainText)
     .def_property_readonly("PlainTextWithFields", &BND_AnnotationBase::PlainTextWithFields)
+    .def_property_readonly("AnnotationType", &BND_AnnotationBase::AnnotationType)
+    .def("WrapText", &BND_AnnotationBase::WrapText, py::arg("wrapwidth"))
+    .def_property("TextIsWrapped", &BND_AnnotationBase::TextIsWrapped, &BND_AnnotationBase::SetTextIsWrapped)
+    .def_property_readonly("Plane", &BND_AnnotationBase::Plane)
+    ;
+
+  py::class_<BND_Text, BND_AnnotationBase>(m, "Text")
+    ;
+
+  py::class_<BND_Leader, BND_AnnotationBase>(m, "Leader")
+    .def_property_readonly("Points", &BND_Leader::GetPoints)
+    .def("GetTextPoint2d", &BND_Leader::GetTextPoint2d, py::arg("dimstyle"), py::arg("leaderscale"))
+    ;
+
+  py::class_<BND_Dimension, BND_AnnotationBase>(m, "Dimension")
+    ;
+
+  py::class_<BND_DimLinear, BND_Dimension>(m, "DimLinear")
+    .def_property_readonly("Points", &BND_DimLinear::GetPoints)
+    .def("GetDisplayLines", &BND_DimLinear::GetDisplayLines, py::arg("dimstyle"))
+    ;
+
+  py::class_<BND_DimAngular, BND_Dimension>(m, "DimAngular")
+    .def_property_readonly("Points", &BND_DimAngular::GetPoints)
+    .def_property_readonly("Radius", &BND_DimAngular::Radius)
+    .def_property_readonly("Angle", &BND_DimAngular::Measurement)
+    .def("GetDisplayLines", &BND_DimAngular::GetDisplayLines, py::arg("dimstyle"))
+    ;
+  py::class_<BND_DimRadial, BND_Dimension>(m, "DimRadial")
+    .def_property_readonly("Points", &BND_DimRadial::GetPoints)
+    .def("GetDisplayLines", &BND_DimRadial::GetDisplayLines, py::arg("dimstyle"))
+    ;
+  py::class_<BND_DimOrdinate, BND_Dimension>(m, "DimOrdinate")
+    .def_property_readonly("Points", &BND_DimOrdinate::GetPoints)
+    .def("GetDisplayLines", &BND_DimOrdinate::GetDisplayLines, py::arg("dimstyle"))
+    ;
+  py::class_<BND_Centermark, BND_Dimension>(m, "Centermark")
+    .def("GetDisplayLines", &BND_Centermark::GetDisplayLines, py::arg("dimstyle"))
     ;
 
   py::class_<BND_TextDot, BND_GeometryBase>(m, "TextDot")
@@ -73,6 +679,7 @@ void initAnnotationBaseBindings(pybind11::module& m)
     .def_property("FontHeight", &BND_TextDot::GetFontHeight, &BND_TextDot::SetFontHeight)
     .def_property("FontFace", &BND_TextDot::GetFontFace, &BND_TextDot::SetFontFace)
     ;
+
 }
 #endif
 
@@ -82,6 +689,8 @@ using namespace emscripten;
 void initAnnotationBaseBindings(void*)
 {
   class_<BND_AnnotationBase, base<BND_GeometryBase>>("AnnotationBase")
+    .property("annotationType", &BND_AnnotationBase::AnnotationType)
+    .property("dimensionStyleId", &BND_AnnotationBase::DimensionStyleId)
     .property("richText", &BND_AnnotationBase::RichText)
     .property("plainText", &BND_AnnotationBase::PlainText)
     .property("plainTextWithFields", &BND_AnnotationBase::PlainTextWithFields)
@@ -95,5 +704,44 @@ void initAnnotationBaseBindings(void*)
     .property("fontHeight", &BND_TextDot::GetFontHeight, &BND_TextDot::SetFontHeight)
     .property("fontFace", &BND_TextDot::GetFontFace, &BND_TextDot::SetFontFace)
     ;
+
+  class_<BND_Leader, base<BND_AnnotationBase>>("Leader")
+    .property("points", &BND_Leader::GetPoints)
+    .function("getTextPoint2d", &BND_Leader::GetTextPoint2d, allow_raw_pointers())
+    ;
+
+  class_<BND_Dimension, base<BND_AnnotationBase>>("Dimension")
+    ;
+
+  class_<BND_DimLinear, base<BND_Dimension>>("DimLinear")
+    .property("points", &BND_DimLinear::GetPoints)
+    .function("getDisplayLines", &BND_DimLinear::GetDisplayLines, allow_raw_pointers())
+    ;
+
+  class_<BND_DimAngular, base<BND_Dimension>>("DimAngular")
+    .property("points", &BND_DimAngular::GetPoints)
+    .property("radius", &BND_DimAngular::Radius)
+    .property("angle", &BND_DimAngular::Measurement)
+    .function("getDisplayLines", &BND_DimAngular::GetDisplayLines, allow_raw_pointers())
+    ;
+
+  class_<BND_DimRadial, base<BND_Dimension>>("DimRadial")
+    .property("points", &BND_DimRadial::GetPoints)
+    .function("getDisplayLines", &BND_DimRadial::GetDisplayLines, allow_raw_pointers())
+    ;
+
+  class_<BND_DimOrdinate, base<BND_Dimension>>("DimOrdinate")
+    .property("points", &BND_DimOrdinate::GetPoints)
+    .function("getDisplayLines", &BND_DimOrdinate::GetDisplayLines, allow_raw_pointers())
+    ;
+
+  class_<BND_Centermark, base<BND_Dimension>>("Centermark")
+    .function("getDisplayLines", &BND_Centermark::GetDisplayLines, allow_raw_pointers())
+    ;
+
+  register_vector<ON_Line>("vector<ON_Line>");
+  register_vector<ON_3dPoint>("vector<ON_3dPoint>");
+  register_vector<BND_Arc>("vector<BND_Arc>");
+
 }
 #endif

--- a/src/bindings/bnd_annotationbase.h
+++ b/src/bindings/bnd_annotationbase.h
@@ -12,34 +12,40 @@ class BND_AnnotationBase : public BND_GeometryBase
 {
   ON_Annotation* m_annotation = nullptr;
 protected:
+  BND_AnnotationBase();
   void SetTrackedPointer(ON_Annotation* annotation, const ON_ModelComponentReference* compref);
 
 public:
-  BND_AnnotationBase(ON_Annotation* annotation, const ON_ModelComponentReference* compref);
+  BND_AnnotationBase(ON_Annotation *annotation, const ON_ModelComponentReference *compref);
   //public Guid DimensionStyleId {get;set;}
-  //public bool HasPropertyOverrides {get;}
-  //public bool IsPropertyOverridden(DimensionStyle.Field field)
-  //public bool ClearPropertyOverrides()
-  //public DimensionStyle GetDimensionStyle(DimensionStyle parentDimStyle)
-  //public DimensionStyle DimensionStyle {get;}
-  //public bool SetOverrideDimStyle(DimensionStyle OverrideStyle)
-  //public DimensionStyle ParentDimensionStyle {get; set;}
-  //public double TextHeight {get; set;}
-  //public bool MaskEnabled { get;set;}
-  //public bool MaskUsesViewportColor{ get; set; }
-  //public DimensionStyle.MaskType MaskColorSource{ get; set; }
-  //public bool DrawTextFrame{ get; set; }
-  //public DimensionStyle.MaskFrame MaskFrame{ get; set; }
-  //public Color MaskColor{ get; set; }
-  //public double MaskOffset{ get; set; }
-  //public double DimensionScale{ get; set; }
-  //public bool DrawForward{ get; set; }
-  //public DocObjects.Font Font{ get; set; }
-  //public DimensionStyle.LengthDisplay DimensionLengthDisplay{ get; set; }
-  //public DimensionStyle.LengthDisplay AlternateDimensionLengthDisplay{ get; set; }
-  //public char DecimalSeparator{ get; set; }
-  //public Plane Plane{ get; set; }
-  //public string GetPlainTextWithRunMap(ref int[] map)
+  ON::AnnotationType AnnotationType() const;
+  BND_UUID DimensionStyleId() const;
+  // public bool HasPropertyOverrides {get;}
+  // public bool IsPropertyOverridden(DimensionStyle.Field field)
+  // public bool ClearPropertyOverrides()
+  // public DimensionStyle GetDimensionStyle(DimensionStyle parentDimStyle)
+  // public DimensionStyle DimensionStyle {get;}
+  //BND_DimensionStyle DimensionStyle();
+  // public bool SetOverrideDimStyle(DimensionStyle OverrideStyle)
+  // public DimensionStyle ParentDimensionStyle {get; set;}
+  // public double TextHeight {get; set;}
+  //  --- double TextHeight() const;
+  //  public bool MaskEnabled { get;set;}
+  //  public bool MaskUsesViewportColor{ get; set; }
+  //  public DimensionStyle.MaskType MaskColorSource{ get; set; }
+  //  public bool DrawTextFrame{ get; set; }
+  //  public DimensionStyle.MaskFrame MaskFrame{ get; set; }
+  //  public Color MaskColor{ get; set; }
+  //  public double MaskOffset{ get; set; }
+  //  public double DimensionScale{ get; set; }
+  //  public bool DrawForward{ get; set; }
+  //  public DocObjects.Font Font{ get; set; }
+  //  public DimensionStyle.LengthDisplay DimensionLengthDisplay{ get; set; }
+  //  public DimensionStyle.LengthDisplay AlternateDimensionLengthDisplay{ get; set; }
+  //  public char DecimalSeparator{ get; set; }
+  //  public Plane Plane{ get; set; }
+  BND_Plane Plane() const;
+  // public string GetPlainTextWithRunMap(ref int[] map)
   std::wstring RichText() const;
   //void SetRichText(const std::wstring& rtf);
   std::wstring PlainText() const;
@@ -59,14 +65,17 @@ public:
   //public double TextModelWidth{ get; }
   //public double FormatWidth{ get; set; }
   //public bool TextIsWrapped{ get; set; }
+  bool TextIsWrapped() const;
+  void SetTextIsWrapped(bool wrapped);
   //public void WrapText()
-  //public double TextRotationRadians{ get; set; }
-  //public double TextRotationDegrees{ get; set; }
-  //public virtual bool SetBold(bool set_on)
-  //public virtual bool SetItalic(bool set_on)
-  //public virtual bool SetUnderline(bool set_on)
-  //public virtual bool SetFacename(bool set_on, string facename)
-  //public bool RunReplace(
+  void WrapText(double wrapWidth);
+  // public double TextRotationRadians{ get; set; }
+  // public double TextRotationDegrees{ get; set; }
+  // public virtual bool SetBold(bool set_on)
+  // public virtual bool SetItalic(bool set_on)
+  // public virtual bool SetUnderline(bool set_on)
+  // public virtual bool SetFacename(bool set_on, string facename)
+  // public bool RunReplace(
 };
 
 
@@ -91,3 +100,103 @@ public:
   std::wstring GetFontFace() const { return std::wstring(m_dot->FontFace()); }
   void SetFontFace(const std::wstring& face) { m_dot->SetFontFace(face.c_str()); }
 };
+
+class BND_Text : public BND_AnnotationBase
+{
+  ON_Text* m_text = nullptr;
+protected:
+  void SetTrackedPointer(ON_Text* text, const ON_ModelComponentReference* compref);
+public:
+  BND_Text(ON_Text* text, const ON_ModelComponentReference* compref);
+};
+
+class BND_Leader : public BND_AnnotationBase
+{
+  ON_Leader* m_leader = nullptr;
+protected:
+  void SetTrackedPointer(ON_Leader* leader, const ON_ModelComponentReference* compref);
+public:
+  BND_Leader(ON_Leader* leader, const ON_ModelComponentReference* compref);
+
+#if defined(ON_PYTHON_COMPILE)
+  std::vector<ON_3dPoint> GetPoints() const;
+#else
+  emscripten::val GetPoints() const;
+#endif
+  ON_2dPoint GetTextPoint2d(const BND_DimensionStyle& dimstyle, double leaderscale) const;
+};
+
+class BND_Dimension : public BND_AnnotationBase
+{
+  ON_Dimension* m_dimension = nullptr;
+protected:
+  BND_Dimension();
+  void SetTrackedPointer(ON_Dimension* dimension, const ON_ModelComponentReference* compref);
+
+public:
+  BND_Dimension(ON_Dimension* dimension, const ON_ModelComponentReference* compref);
+};
+
+class BND_DimLinear : public BND_Dimension
+{
+  ON_DimLinear* m_dimLinear= nullptr;
+protected:
+  void SetTrackedPointer(ON_DimLinear* dimLinear, const ON_ModelComponentReference* compref);
+
+public:
+  BND_DimLinear(ON_DimLinear* dimLinear, const ON_ModelComponentReference* compref);
+  BND_DICT GetPoints() const;
+  BND_DICT GetDisplayLines(const BND_DimensionStyle& dimStyle);
+};
+
+class BND_DimAngular : public BND_Dimension
+{
+  ON_DimAngular* m_dimAngular= nullptr;
+protected:
+  void SetTrackedPointer(ON_DimAngular *dimAngular, const ON_ModelComponentReference *compref);
+
+public:
+  BND_DimAngular(ON_DimAngular* dimAngular, const ON_ModelComponentReference* compref);
+
+  BND_DICT GetPoints() const;
+  BND_DICT GetDisplayLines(const BND_DimensionStyle& dimStyle);
+  double Radius() const;
+  double Measurement() const;
+};
+
+class BND_DimRadial : public BND_Dimension
+{
+  ON_DimRadial* m_dimRadial= nullptr;
+protected:
+  void SetTrackedPointer(ON_DimRadial* dimRadial, const ON_ModelComponentReference* compref);
+
+public:
+  BND_DimRadial(ON_DimRadial* dimRadial, const ON_ModelComponentReference* compref);
+  BND_DICT GetPoints() const;
+  BND_DICT GetDisplayLines(const BND_DimensionStyle& dimStyle);
+
+};
+
+class BND_DimOrdinate : public BND_Dimension
+{
+  ON_DimOrdinate* m_dimOrdinate= nullptr;
+protected:
+  void SetTrackedPointer(ON_DimOrdinate* dimOrdinate, const ON_ModelComponentReference* compref);
+
+public:
+  BND_DimOrdinate(ON_DimOrdinate* dimOrdinate, const ON_ModelComponentReference* compref);
+  BND_DICT GetPoints() const;
+  BND_DICT GetDisplayLines(const BND_DimensionStyle& dimStyle);
+};
+
+class BND_Centermark : public BND_Dimension
+{
+  ON_Centermark* m_centermark= nullptr;
+protected:
+  void SetTrackedPointer(ON_Centermark* centermark, const ON_ModelComponentReference* compref);
+
+public:
+  BND_Centermark(ON_Centermark* centermark, const ON_ModelComponentReference* compref);
+  std::vector<ON_Line> GetDisplayLines(const BND_DimensionStyle& dimStyle);
+};
+

--- a/src/bindings/bnd_defines.cpp
+++ b/src/bindings/bnd_defines.cpp
@@ -18,6 +18,16 @@ static bool TransformLine(ON_Line& line, const BND_Transform& xform)
   return line.Transform(xform.m_xform);
 }
 
+static std::vector<ON_2dPoint> ArrowPoints(ON_Arrowhead::arrow_type arrowType, double size)
+{
+  ON_2dPointArray points;
+  ON_Arrowhead::GetPoints(arrowType, points);
+  std::vector<ON_2dPoint> rc(points.Count());
+  for (int i = 0; i < points.Count(); i++)
+    rc[i] = points[i];
+  return rc;
+}
+
 #if defined(ON_PYTHON_COMPILE)
 namespace py = pybind11;
 void initDefines(pybind11::module& m)
@@ -72,6 +82,10 @@ void initDefines(pybind11::module& m)
     .def("PointAt", &ON_Line::PointAt, py::arg("t"))
     .def("Transform", &TransformLine, py::arg("xform"))
     ;
+
+  py::class_<ON_Arrowhead>(m, "Arrowhead")
+      .def_static("GetPoints", &ArrowPoints, py::arg("arrowType"), py::arg("size"))
+      ;
 
   py::enum_<LoftType>(m, "LoftType")
     .value("Normal", LoftType::Normal)
@@ -272,6 +286,34 @@ void initDefines(pybind11::module& m)
     .value("Box" , ON_CurvePiping::CapTypes::Box)
     .value("Dome", ON_CurvePiping::CapTypes::Dome)
     ;
+
+  py::enum_<ON::AnnotationType>(m, "AnnotationTypes")
+      .value("Unset", ON::AnnotationType::Unset)
+      .value("Aligned", ON::AnnotationType::Aligned)
+      .value("Angular", ON::AnnotationType::Angular)
+      .value("Diameter", ON::AnnotationType::Diameter)
+      .value("Radius", ON::AnnotationType::Radius)
+      .value("Rotated", ON::AnnotationType::Rotated)
+      .value("Ordinate", ON::AnnotationType::Ordinate)
+      .value("ArcLen", ON::AnnotationType::ArcLen)
+      .value("CenterMark", ON::AnnotationType::CenterMark)
+      .value("Text", ON::AnnotationType::Text)
+      .value("Leader", ON::AnnotationType::Leader)
+      .value("Angular3pt", ON::AnnotationType::Angular3pt)
+    ;
+
+  py::enum_<ON_Arrowhead::arrow_type>(m, "ArrowheadTypes")
+      .value("None", ON_Arrowhead::arrow_type::None)
+      .value("UserBlock", ON_Arrowhead::arrow_type::UserBlock)
+      .value("SolidTriangle", ON_Arrowhead::arrow_type::SolidTriangle)
+      .value("Dot", ON_Arrowhead::arrow_type::Dot)
+      .value("Tick", ON_Arrowhead::arrow_type::Tick)
+      .value("ShortTriangle", ON_Arrowhead::arrow_type::ShortTriangle)
+      .value("OpenArrow", ON_Arrowhead::arrow_type::OpenArrow)
+      .value("Rectangle", ON_Arrowhead::arrow_type::Rectangle)
+      .value("LongTriangle", ON_Arrowhead::arrow_type::LongTriangle)
+      .value("LongerTriangle", ON_Arrowhead::arrow_type::LongerTriangle)
+    ;
 }
 
 pybind11::dict PointToDict(const ON_3dPoint& point)
@@ -378,8 +420,17 @@ void initDefines(void*)
     .constructor<ON_3dPoint, ON_3dPoint>()
     .property("from", &ON_Line::from)
     .property("to", &ON_Line::to)
-    .property("length", &ON_Line::Length);
+    .property("length", &ON_Line::Length)
+    .property("isValid", &ON_Line::IsValid)
+    .property("direction", &ON_Line::Direction)
+    .property("unitTangent", &ON_Line::Tangent)
+    .function("pointAt", &ON_Line::PointAt, allow_raw_pointers())
+    .function("transform", &TransformLine, allow_raw_pointers())
+    ;
 
+  class_<ON_Arrowhead>("Arrowhead")
+    .class_function("getPoints", &ArrowPoints, allow_raw_pointers())
+    ;
 
   enum_<ON::object_mode>("ObjectMode")
     .value("Normal", ON::object_mode::normal_object)
@@ -571,6 +622,36 @@ void initDefines(void*)
     .value("Box" , ON_CurvePiping::CapTypes::Box)
     .value("Dome", ON_CurvePiping::CapTypes::Dome)
     ;
+
+  enum_<ON::AnnotationType>("AnnotationTypes")
+      .value("Unset", ON::AnnotationType::Unset)
+      .value("Aligned", ON::AnnotationType::Aligned)
+      .value("Angular", ON::AnnotationType::Angular)
+      .value("Diameter", ON::AnnotationType::Diameter)
+      .value("Radius", ON::AnnotationType::Radius)
+      .value("Rotated", ON::AnnotationType::Rotated)
+      .value("Ordinate", ON::AnnotationType::Ordinate)
+      .value("ArcLen", ON::AnnotationType::ArcLen)
+      .value("CenterMark", ON::AnnotationType::CenterMark)
+      .value("Text", ON::AnnotationType::Text)
+      .value("Leader", ON::AnnotationType::Leader)
+      .value("Angular3pt", ON::AnnotationType::Angular3pt)
+    ;
+
+  enum_<ON_Arrowhead::arrow_type>("ArrowheadTypes")
+      .value("None", ON_Arrowhead::arrow_type::None)
+      .value("UserBlock", ON_Arrowhead::arrow_type::UserBlock)
+      .value("SolidTriangle", ON_Arrowhead::arrow_type::SolidTriangle)
+      .value("Dot", ON_Arrowhead::arrow_type::Dot)
+      .value("Tick", ON_Arrowhead::arrow_type::Tick)
+      .value("ShortTriangle", ON_Arrowhead::arrow_type::ShortTriangle)
+      .value("OpenArrow", ON_Arrowhead::arrow_type::OpenArrow)
+      .value("Rectangle", ON_Arrowhead::arrow_type::Rectangle)
+      .value("LongTriangle", ON_Arrowhead::arrow_type::LongTriangle)
+      .value("LongerTriangle", ON_Arrowhead::arrow_type::LongerTriangle)
+    ;
+
+  register_vector<ON_2dPoint>("vector<ON_2dPoint>");
 }
 
 

--- a/src/bindings/bnd_dimensionstyle.cpp
+++ b/src/bindings/bnd_dimensionstyle.cpp
@@ -28,6 +28,21 @@ void BND_DimensionStyle::SetFont(const BND_Font* font)
     m_dimstyle->SetFont(*font->m_managed_font);
 }
 
+ON_Arrowhead::arrow_type BND_DimensionStyle::ArrowType1() const
+{
+  return m_dimstyle->ArrowType1();
+}
+
+ON_Arrowhead::arrow_type BND_DimensionStyle::ArrowType2() const
+{
+  return m_dimstyle->ArrowType2();
+}
+
+ON_Arrowhead::arrow_type BND_DimensionStyle::LeaderArrowType() const
+{
+  return m_dimstyle->LeaderArrowType();
+}
+
 
 #if defined(ON_PYTHON_COMPILE)
 namespace py = pybind11;
@@ -53,9 +68,13 @@ void initDimensionStyleBindings(pybind11::module& m)
     .def_property("TextUnderlined", &BND_DimensionStyle::GetTextUnderlined, &BND_DimensionStyle::SetTextUnderlined)
     .def_property("ArrowLength", &BND_DimensionStyle::GetArrowSize, &BND_DimensionStyle::SetArrowSize)
     .def_property("LeaderArrowLength", &BND_DimensionStyle::GetLeaderArrowSize, &BND_DimensionStyle::SetLeaderArrowSize)
+    .def_property_readonly("ArrowType1", &BND_DimensionStyle::ArrowType1)
+    .def_property_readonly("ArrowType2", &BND_DimensionStyle::ArrowType2)
+    .def_property_readonly("LeaderArrowType", &BND_DimensionStyle::LeaderArrowType)
     .def_property("CentermarkSize", &BND_DimensionStyle::GetCenterMark, &BND_DimensionStyle::SetCenterMark)
     .def_property("TextGap", &BND_DimensionStyle::GetTextGap, &BND_DimensionStyle::SetTextGap)
     .def_property("TextHEight", &BND_DimensionStyle::GetTextHeight, &BND_DimensionStyle::SetTextHeight)
+    .def_property("TextHeight", &BND_DimensionStyle::GetTextHeight, &BND_DimensionStyle::SetTextHeight)
     .def_property("LengthFactor", &BND_DimensionStyle::GetLengthFactor, &BND_DimensionStyle::SetLengthFactor)
     .def_property("AlternateLengthFactor", &BND_DimensionStyle::GetAlternateLengthFactor, &BND_DimensionStyle::SetAlternateLengthFactor)
     .def_property("ToleranceUpperValue", &BND_DimensionStyle::GetToleranceUpperValue, &BND_DimensionStyle::SetToleranceUpperValue)
@@ -65,6 +84,11 @@ void initDimensionStyleBindings(pybind11::module& m)
     .def_property("TextRotation", &BND_DimensionStyle::GetTextRotation, &BND_DimensionStyle::SetTextRotation)
     .def_property("StackHeightScale", &BND_DimensionStyle::GetStackHeightScale, &BND_DimensionStyle::SetStackHeightScale)
     .def_property("LeaderLandingLength", &BND_DimensionStyle::GetLeaderLandingLength, &BND_DimensionStyle::SetLeaderLandingLength)
+    .def_property("ExtensionLineExtension", &BND_DimensionStyle::GetExtExtension, &BND_DimensionStyle::SetExtExtension)
+    .def_property("ExtensionLineOffset", &BND_DimensionStyle::GetExtOffset, &BND_DimensionStyle::SetExtOffset)
+    .def_property("DimensionLineExtension", &BND_DimensionStyle::GetDimExtension, &BND_DimensionStyle::SetDimExtension)
+    .def_property("FixedExtensionLength", &BND_DimensionStyle::GetFixedExtensionLen, &BND_DimensionStyle::SetFixedExtensionLen)
+    .def_property("FixedExtensionLengthOn", &BND_DimensionStyle::GetFixedExtensionLenOn, &BND_DimensionStyle::SetFixedExtensionLenOn)
     .def("IsFieldOverridden", &BND_DimensionStyle::IsFieldOverriden, py::arg("field"))
     .def("SetFieldOverride", &BND_DimensionStyle::SetFieldOverride, py::arg("field"))
     .def("ClearFieldOverride", &BND_DimensionStyle::ClearFieldOverride, py::arg("field"))
@@ -210,9 +234,13 @@ void initDimensionStyleBindings(void*)
     .property("textUnderlined", &BND_DimensionStyle::GetTextUnderlined, &BND_DimensionStyle::SetTextUnderlined)
     .property("arrowLength", &BND_DimensionStyle::GetArrowSize, &BND_DimensionStyle::SetArrowSize)
     .property("leaderArrowLength", &BND_DimensionStyle::GetLeaderArrowSize, &BND_DimensionStyle::SetLeaderArrowSize)
+    .property("arrowType1", &BND_DimensionStyle::ArrowType1)
+    .property("arrowType2", &BND_DimensionStyle::ArrowType2)
+    .property("leaderArrowType", &BND_DimensionStyle::LeaderArrowType)
     .property("centermarkSize", &BND_DimensionStyle::GetCenterMark, &BND_DimensionStyle::SetCenterMark)
     .property("textGap", &BND_DimensionStyle::GetTextGap, &BND_DimensionStyle::SetTextGap)
     .property("textHEight", &BND_DimensionStyle::GetTextHeight, &BND_DimensionStyle::SetTextHeight)
+    .property("textHeight", &BND_DimensionStyle::GetTextHeight, &BND_DimensionStyle::SetTextHeight)
     .property("lengthFactor", &BND_DimensionStyle::GetLengthFactor, &BND_DimensionStyle::SetLengthFactor)
     .property("alternateLengthFactor", &BND_DimensionStyle::GetAlternateLengthFactor, &BND_DimensionStyle::SetAlternateLengthFactor)
     .property("toleranceUpperValue", &BND_DimensionStyle::GetToleranceUpperValue, &BND_DimensionStyle::SetToleranceUpperValue)
@@ -222,6 +250,11 @@ void initDimensionStyleBindings(void*)
     .property("textRotation", &BND_DimensionStyle::GetTextRotation, &BND_DimensionStyle::SetTextRotation)
     .property("stackHeightScale", &BND_DimensionStyle::GetStackHeightScale, &BND_DimensionStyle::SetStackHeightScale)
     .property("leaderLandingLength", &BND_DimensionStyle::GetLeaderLandingLength, &BND_DimensionStyle::SetLeaderLandingLength)
+    .property("extensionLineExtension", &BND_DimensionStyle::GetExtExtension, &BND_DimensionStyle::SetExtExtension)
+    .property("extensionLineOffset", &BND_DimensionStyle::GetExtOffset, &BND_DimensionStyle::SetExtOffset)
+    .property("dimensionLineExtension", &BND_DimensionStyle::GetDimExtension, &BND_DimensionStyle::SetDimExtension)
+    .property("fixedExtensionLength", &BND_DimensionStyle::GetFixedExtensionLen, &BND_DimensionStyle::SetFixedExtensionLen)
+    .property("fixedExtensionLengthOn", &BND_DimensionStyle::GetFixedExtensionLenOn, &BND_DimensionStyle::SetFixedExtensionLenOn)
     .function("clearAllFieldOverrides", &BND_DimensionStyle::ClearAllFieldOverrides)
     .property("hasFieldOverrides", &BND_DimensionStyle::HasFieldOverrides)
     .property("isChild", &BND_DimensionStyle::IsChild)

--- a/src/bindings/bnd_dimensionstyle.h
+++ b/src/bindings/bnd_dimensionstyle.h
@@ -38,25 +38,31 @@ public:
   BND_UUID GetLeaderArrowBlockId() const { return ON_UUID_to_Binding(m_dimstyle->LeaderArrowBlockId()); }
   void SetLeaderArrowBlockId(BND_UUID id) { m_dimstyle->SetLeaderArrowBlockId(Binding_to_ON_UUID(id)); }
 
+  ON_Arrowhead::arrow_type ArrowType1() const;
+  ON_Arrowhead::arrow_type ArrowType2() const;
+  ON_Arrowhead::arrow_type LeaderArrowType() const;
+
   DIMSTYLE_PROPERTY(bool, SuppressExtension1)
   DIMSTYLE_PROPERTY(bool, SuppressExtension2)
   DIMSTYLE_PROPERTY(bool, SuppressArrow1)
   DIMSTYLE_PROPERTY(bool, SuppressArrow2)
-  
+
   //public bool AlternateUnitsDisplay | get; set;
   bool GetAlternateBelowLine() const { return m_dimstyle->AlternateBelow(); }
   void SetAlternateBelowLine(bool b) { m_dimstyle->SetAlternateBelow(b); }
   DIMSTYLE_PROPERTY(bool, DrawTextMask)
     //public bool FixedExtensionOn | get; set;
+    DIMSTYLE_PROPERTY(bool, FixedExtensionLenOn)
 
     DIMSTYLE_PROPERTY(bool, LeaderHasLanding)
     DIMSTYLE_PROPERTY(bool, DrawForward)
     DIMSTYLE_PROPERTY(bool, TextUnderlined)
 
     //  DIMSTYLE_PROPERTY(double, MaskOffest)
-    //  DIMSTYLE_PROPERTY(double, ExtensionLineExtension)
-    //  DIMSTYLE_PROPERTY(double, ExtensionLineOffset)
-      //public double DimensionLineExtension | get; set;
+    DIMSTYLE_PROPERTY(double, ExtExtension)
+    DIMSTYLE_PROPERTY(double, ExtOffset)
+    DIMSTYLE_PROPERTY(double, DimExtension)
+    // public double DimensionLineExtension | get; set;
     DIMSTYLE_PROPERTY(double, ArrowSize) //ArrowLength
     DIMSTYLE_PROPERTY(double, LeaderArrowSize) //LeaderArrowLength
     DIMSTYLE_PROPERTY(double, CenterMark) //CentermarkSize
@@ -69,7 +75,7 @@ public:
     DIMSTYLE_PROPERTY(double, ToleranceHeightScale)
     DIMSTYLE_PROPERTY(double, BaselineSpacing)
     //DIMSTYLE_PROPERTY(double, DimensionScale)
-    //DIMSTYLE_PROPERTY(double, FixedExtensionLength)
+    DIMSTYLE_PROPERTY(double, FixedExtensionLen)
     DIMSTYLE_PROPERTY(double, TextRotation)
     DIMSTYLE_PROPERTY(double, StackHeightScale)
     //DIMSTYLE_PROPERTY(double, Roundoff)
@@ -103,7 +109,7 @@ public:
     //public TextHorizontalAlignment TextHorizontalAlignment | get; set;
     //public TextVerticalAlignment LeaderTextVerticalAlignment | get; set;
     //public TextHorizontalAlignment LeaderTextHorizontalAlignment | get; set;
-    //public TextLocation DimTextLocation | get; set; 
+    //public TextLocation DimTextLocation | get; set;
     //public TextLocation DimRadialTextLocation | get; set;
     //public LeaderCurveStyle LeaderCurveType | get; set;
     //public LeaderContentAngleStyle DimTextAngleType | get; set;

--- a/src/bindings/bnd_object.cpp
+++ b/src/bindings/bnd_object.cpp
@@ -163,7 +163,42 @@ BND_CommonObject* BND_CommonObject::CreateWrapper(ON_Object* obj, const ON_Model
 
     ON_Annotation* annotation = ON_Annotation::Cast(obj);
     if (annotation)
+    {
+      ON_Text* text = ON_Text::Cast(obj);
+      if (text)
+        return new BND_Text(text, compref);
+
+      ON_Leader* leader = ON_Leader::Cast(obj);
+      if(leader)
+        return new BND_Leader(leader, compref);
+
+      ON_Dimension* dimension = ON_Dimension::Cast(obj);
+      if( dimension )
+      {
+        ON_DimLinear* dimlinear = ON_DimLinear::Cast(obj);
+        if(dimlinear)
+          return new BND_DimLinear(dimlinear, compref);
+
+        ON_DimAngular* dimangular = ON_DimAngular::Cast(obj);
+        if(dimangular)
+          return new BND_DimAngular(dimangular, compref);
+
+        ON_DimRadial* dimradial = ON_DimRadial::Cast(obj);
+        if(dimradial)
+          return new BND_DimRadial(dimradial, compref);
+
+        ON_DimOrdinate* dimordinate = ON_DimOrdinate::Cast(obj);
+        if(dimordinate)
+          return new BND_DimOrdinate(dimordinate, compref);
+
+        ON_Centermark* centermark = ON_Centermark::Cast(obj);
+        if(centermark)
+          return new BND_Centermark(centermark, compref);
+
+        return new BND_Dimension(dimension, compref);
+      }
       return new BND_AnnotationBase(annotation, compref);
+    }
 
     ON_TextDot* dot = ON_TextDot::Cast(obj);
     if (dot)

--- a/src/bindings/bnd_plane.cpp
+++ b/src/bindings/bnd_plane.cpp
@@ -79,6 +79,27 @@ BND_Plane BND_Plane::Unset()
   return rc;
 }
 
+ON_3dPoint BND_Plane::PointAtUV(double u, double v) const
+{
+  ON_Plane plane = ToOnPlane();
+  return plane.PointAt(u, v);
+}
+
+ON_3dPoint BND_Plane::PointAtUVW(double u, double v, double w) const
+{
+  ON_Plane plane = ToOnPlane();
+  return plane.PointAt(u, v, w);
+}
+
+BND_Plane BND_Plane::Rotate(double angle, const ON_3dVector &axis)
+{
+  ON_Plane plane = ToOnPlane();
+  if(plane.Rotate(angle, axis))
+    return FromOnPlane(plane);
+
+  return *this;
+}
+
 #if defined(ON_WASM_COMPILE)
 emscripten::val BND_Plane::Encode() const
 {
@@ -182,6 +203,9 @@ void initPlaneBindings(pybind11::module& m)
     .def(py::init<ON_3dPoint, ON_3dPoint, ON_3dPoint>(), py::arg("origin"), py::arg("xPoint"), py::arg("yPoint"))
     .def(py::init<ON_3dPoint, ON_3dVector, ON_3dVector>(), py::arg("origin"), py::arg("xDirection"), py::arg("yDirection"))
     .def(py::init<double, double, double, double>(), py::arg("a"), py::arg("b"), py::arg("c"), py::arg("d"))
+    .def("PointAt", &BND_Plane::PointAtUV, py::arg("u"), py::arg("v"))
+    .def("PointAt", &BND_Plane::PointAtUVW, py::arg("u"), py::arg("v"), py::arg("w"))
+    .def("Rotate", &BND_Plane::Rotate, py::arg("angle"), py::arg("axis"))
     .def_readwrite("Origin", &BND_Plane::m_origin)
     .def_readwrite("XAxis", &BND_Plane::m_xaxis)
     .def_readwrite("YAxis", &BND_Plane::m_yaxis)

--- a/src/bindings/bnd_plane.h
+++ b/src/bindings/bnd_plane.h
@@ -17,12 +17,17 @@ public:
   BND_Plane(ON_3dPoint origin, ON_3dVector xDirection, ON_3dVector yDirection);
   BND_Plane(double a, double b, double c, double d);
 
+  BND_Plane Rotate(double angle, const ON_3dVector &axis);
+
   ON_Plane ToOnPlane() const;
   static BND_Plane FromOnPlane(const ON_Plane& plane);
   static BND_Plane WorldXY();
   static BND_Plane WorldYZ();
   static BND_Plane WorldZX();
   static BND_Plane Unset();
+
+  ON_3dPoint PointAtUV(double u, double v) const;
+  ON_3dPoint PointAtUVW(double u, double v, double w) const;
 
 #if defined(__EMSCRIPTEN__)
   emscripten::val toJSON(emscripten::val key);

--- a/src/bindings/bnd_point.cpp
+++ b/src/bindings/bnd_point.cpp
@@ -85,6 +85,16 @@ static pybind11::dict EncodeVector3d(const ON_3dVector& v)
   return d;
 }
 
+static double ON_3dVectorLength(const ON_3dVector& a)
+{
+  return a.Length();
+}
+
+static void ON_3dVectorUnitize(ON_3dVector& a)
+{
+  a.Unitize();
+}
+
 static int ON_3dVectorIsParallelTo(const ON_3dVector& a, const ON_3dVector& b)
 {
   return a.IsParallelTo(b);
@@ -98,7 +108,7 @@ static double ON_3dVectorVectorAngle(ON_3dVector a, ON_3dVector b)
 {
   if (!a.Unitize() || !b.Unitize())
     return ON_UNSET_VALUE;
-  
+
   //compute dot product
   double dot = a.x * b.x + a.y * b.y + a.z * b.z;
   // remove any "noise"
@@ -194,6 +204,16 @@ static double ON_3dVectorVectorAngle3(ON_3dVector v1, ON_3dVector v2, ON_3dVecto
     dAngle = (ON_PI * 2.0) - dAngle;
 
   return dAngle;
+}
+
+static ON_3dVector ON_3dVectorCrossProduct(const ON_3dVector& a, const ON_3dVector& b)
+{
+  return ON_3dVector::CrossProduct(a, b);
+}
+
+static double ON_3dVectorDotProduct(const ON_3dVector& a, const ON_3dVector& b)
+{
+  return a * b;
 }
 
 
@@ -342,6 +362,10 @@ void initPointBindings(pybind11::module& m)
     .def("__repr__", &ReprVector3d)
     .def("IsParallelTo", &ON_3dVectorIsParallelTo, py::arg("other"))
     .def("IsParallelTo", &ON_3dVectorIsParallelTo2, py::arg("other"), py::arg("angleTolerance"))
+    .def("Unitize", &ON_3dVectorUnitize)
+    .def("Length", &ON_3dVectorLength)
+    .def_static("CrossProduct", &ON_3dVectorCrossProduct, py::arg("a"), py::arg("b"))
+    .def_static("DotProduct", &ON_3dVectorDotProduct, py::arg("a"), py::arg("b"))
     .def_static("VectorAngle", &ON_3dVectorVectorAngle, py::arg("a"), py::arg("b"))
     .def_static("VectorAngle", &ON_3dVectorVectorAngle2, py::arg("a"), py::arg("b"), py::arg("plane"))
     .def_static("VectorAngle", &ON_3dVectorVectorAngle3, py::arg("v1"), py::arg("v2"), py::arg("vNormal"))


### PR DESCRIPTION
* annotation type
* arrow head types
* arrow head points
* different annotation types
  * Points/points: give 3d points for the given annotation. These are
    returned in dictionaries with string keys that describe what the
    points are used for. The naming is based on the C++ signature
  * GetDisplayLines/getDisplayLines: give lines, arcs etc for
    the given annotation. These are returned in a dictionary with
    entries "lines", "arcs" where it makes sense
* added some API to other types where it supports the reading of
  annotations, including dimstyle, vector and plane API expansion.

The API additions are for both Python and JavaScript.