### PR TITLE
Swap order of "add" arguments.

### DIFF
--- a/src/js/rhino3dm.d.ts
+++ b/src/js/rhino3dm.d.ts
@@ -3124,11 +3124,11 @@ declare module 'rhino3dm' {
 		addBrep(brep:Brep): string;
 		/**
 		 * @description Duplicates the object, then adds a copy of the object to the document.
-		 * @param {ObjectAttributes} attributes
 		 * @param {GeometryBase} geometry
+		 * @param {ObjectAttributes} attributes
 		 * @returns {string} A unique identifier for the object.
 		 */
-		add(attributes: ObjectAttributes, geometry: GeometryBase): string;
+		add(geometry: GeometryBase, attributes: ObjectAttributes): string;
 		/** ... */
 		addObject(): void;
 		/**


### PR DESCRIPTION
The TypeScript bindings are not reflecting the actual argument order for the `add` method in `File3dmObjectTable`.