### PR TITLE
[JS] fix: type mismatch in fromByteArray: File3dm

### DIFF
--- a/src/js/rhino3dm.d.ts
+++ b/src/js/rhino3dm.d.ts
@@ -2742,7 +2742,7 @@ declare module 'rhino3dm' {
 		 * @description Read a 3dm file from a byte array
 		 * @returns {File3dm} New File3dm on success, null on error.
 		 */
-		static fromByteArray(length:number, buffer: Uint8Array): File3dm;
+		static fromByteArray(buffer: Uint8Array): File3dm;
 		/** ... */
 		settings(): File3dmSettings;
 		/** ... */


### PR DESCRIPTION
Opening this in case someone else has run afoul of this with typescript.

At runtime, after transpiling a Jupyter widget that uses `rhino3dm.js`, I was getting the following error:
```
22:18:49.603 Error loading Rhino file: 
message: "function File3dm.fromByteArray called with 2 arguments, expected 1 args!"​
name: "BindingError"
stack: "BindingError: function File3dm.fromByteArray called with 2 arguments, expected 1 args!\n./node_modules/rhino3dm/rhino3dm.js/rhino3dm/extendError/errorClass<@http://localhost:8888/lab/extensions/rhino-inside-jupyter/static/vendors-node_modules_rhino3dm_rhino3dm_js.11d87ae55439add75335.js:755:79097\nBindingError@http://localhost:8888/lab/extensions/rhino-inside-jupyter/static/vendors-
```

This was fixed in my program when I modified the `rhino3dm.d.ts` file before running `jlpm build` (and also changing the function call within my application to have a single argument.

It looks like the function signature in python also has a single argument: https://github.com/mcneel/rhino3dm/blob/2be29689d99a9b8c0b511e3646cbe38a0bad6a81/src/rhino3dm/__init__.pyi#L279