### PR TITLE
[Python] Remove temporary files for testing

### DIFF
--- a/tests/python/test_File3dm_LayerTable.py
+++ b/tests/python/test_File3dm_LayerTable.py
@@ -1,5 +1,6 @@
 import rhino3dm
 import unittest
+from os import remove
 
 #objective: to test creating file with layers and reasing a file with layers
 class TestFile3dmLayerTable(unittest.TestCase):
@@ -29,6 +30,10 @@ class TestFile3dmLayerTable(unittest.TestCase):
         qtyLayers2 = len(file.Layers)
 
         self.assertTrue(qtyLayers == 2 and qtyLayers2 == 2)
+
+        # delete temporary file
+        remove("test_createFileWithLayers.3dm")
+
 
 if __name__ == '__main__':
     print("running tests")

--- a/tests/python/test_File3dm_ViewTable.py
+++ b/tests/python/test_File3dm_ViewTable.py
@@ -1,5 +1,6 @@
 import rhino3dm
 import unittest
+from os import remove
 
 #objective: to test creating file with layers and reasing a file with layers
 class TestFile3dmViewTable(unittest.TestCase):
@@ -25,7 +26,7 @@ class TestFile3dmViewTable(unittest.TestCase):
         loc = rhino3dm.Point3d(50, 50, 50)
 
         view.Viewport.SetCameraLocation(loc)
-        
+
         loc2 = view.Viewport.CameraLocation
 
         file3dm.Views.Add(view)
@@ -37,6 +38,10 @@ class TestFile3dmViewTable(unittest.TestCase):
         loc_read = vi_read.Viewport.CameraLocation
 
         self.assertTrue(loc == loc_read and loc2 == loc_read)
+
+        # delete temporary file
+        remove("CreateFileWithView_py.3dm")
+
 
 if __name__ == '__main__':
     print("running tests")

--- a/tests/python/test_Object_UserString.py
+++ b/tests/python/test_Object_UserString.py
@@ -1,5 +1,6 @@
 import rhino3dm
 import unittest
+from os import remove
 
 #objective: to test that adding a user string to an object and reading it back returns the same string
 class TestObject(unittest.TestCase):
@@ -25,6 +26,10 @@ class TestObject(unittest.TestCase):
         valueRead = obj.Attributes.GetUserString(key)
 
         self.assertTrue( value == valueRead )
+
+        # delete temporary file
+        remove("test_Object_UserString.3dm")
+
 
 if __name__ == '__main__':
     print("running tests")


### PR DESCRIPTION
Temporary files created for testing purpose should be deleted at the end of the test.
Doing it manually when running the test suite in local is annoying.