### PR TITLE
[BUG] Fix Add method in LayerTable

### DIFF
--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -956,10 +956,11 @@ BND_Bitmap* BND_File3dmBitmapTable::FindId(BND_UUID id)
 
 int BND_File3dmLayerTable::Add(const BND_Layer& layer)
 {
-  const ON_Layer* l = layer.m_layer;
+  ON_Layer* l = layer.m_layer;
   ON_ModelComponentReference mr = m_model->AddModelComponent(*l);
   const ON_Layer* managed_layer = ON_Layer::FromModelComponentRef(mr, nullptr);
   int layer_index = (nullptr != managed_layer) ? managed_layer->Index() : ON_UNSET_INT_INDEX;
+  layer.m_layer->SetIndex(layer_index);
   return layer_index;
 }
 

--- a/tests/python/test_File3dm_LayerTable.py
+++ b/tests/python/test_File3dm_LayerTable.py
@@ -3,6 +3,21 @@ import unittest
 
 #objective: to test creating file with layers and reasing a file with layers
 class TestFile3dmLayerTable(unittest.TestCase):
+    def test_Add(self) -> None:
+        """Test for the Add method of File3dmLayerTable.
+        """
+        file3dm = rhino3dm.File3dm()
+        file3dm.ApplicationName = 'python'
+        file3dm.ApplicationDetails = 'rhino3dm-tests-Add'
+        file3dm.ApplicationUrl = 'https://rhino3d.com'
+
+        # create layer
+        layer_index_0 = rhino3dm.Layer()
+        # add the layer to the table the update the index accordingly
+        file3dm.Layers.Add(layer_index_0)
+
+        self.assertEqual(layer_index_0.Index, 0)
+
     def test_createFileWithLayers(self):
 
         file3dm = rhino3dm.File3dm()


### PR DESCRIPTION
The `Add` method in `File3dmLayerTable` does not update the layer `Index` after adding it to the table, so the return value is lost and the original layer object is not anymore consistent with the table.
Not sure if this is the intended behavior or a bug though.

Test has been added.