### PR TITLE
[Python] AddPoint with attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ diff:
 - (js) BND_PointCloud::CreateFromThreeJSON #642
 - (js) Added several methods and properties for Planes #568
 - (dotnet) Linux release builds in an Amazon Linux 2023 container
+- (py) AddPoint now supports attributes #665 @StudioWEngineers
 
 ### Changed
 

--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -432,6 +432,13 @@ BND_UUID BND_ONXModel_ObjectTable::AddPoint1(double x, double y, double z)
   return ON_UUID_to_Binding(rc);
 }
 
+BND_UUID BND_ONXModel_ObjectTable::AddPoint6(double x, double y, double z, const BND_3dmObjectAttributes* attributes)
+{
+  ON_Point point_geometry(x,y,z);
+  ON_UUID rc = Internal_ONX_Model_AddModelGeometry(m_model.get(), &point_geometry, attributes);
+  return ON_UUID_to_Binding(rc);
+}
+
 BND_UUID BND_ONXModel_ObjectTable::AddPointCloud(const BND_PointCloud& cloud, const BND_3dmObjectAttributes* attributes)
 {
   const ON_Geometry* g = cloud.GeometryPointer();
@@ -1705,8 +1712,11 @@ void initExtensionsBindings(rh3dmpymodule& m)
     .def("__iter__", [](py::object s) { return PyBNDIterator<BND_ONXModel_ObjectTable&, BND_FileObject*>(s.cast<BND_ONXModel_ObjectTable &>(), s); })
 #endif
     .def("AddPoint", &BND_ONXModel_ObjectTable::AddPoint1, py::arg("x"), py::arg("y"), py::arg("z"))
+    .def("AddPoint", &BND_ONXModel_ObjectTable::AddPoint6, py::arg("x"), py::arg("y"), py::arg("z"), py::arg("attributes"))
     .def("AddPoint", &BND_ONXModel_ObjectTable::AddPoint2, py::arg("point"))
+    .def("AddPoint", &BND_ONXModel_ObjectTable::AddPoint3, py::arg("point"), py::arg("attributes"))
     .def("AddPoint", &BND_ONXModel_ObjectTable::AddPoint4, py::arg("point"))
+    .def("AddPoint", &BND_ONXModel_ObjectTable::AddPoint5, py::arg("point"), py::arg("attributes"))
     .def("AddPointCloud", &BND_ONXModel_ObjectTable::AddPointCloud, py::arg("cloud"), py::arg("attributes")=nullptr)
     .def("AddLine", &BND_ONXModel_ObjectTable::AddLine1, py::arg("from"), py::arg("to"))
     .def("AddPolyline", &BND_ONXModel_ObjectTable::AddPolyline1, py::arg("polyline"), py::arg("attributes")=nullptr)

--- a/src/bindings/bnd_extensions.h
+++ b/src/bindings/bnd_extensions.h
@@ -29,10 +29,11 @@ class BND_ONXModel_ObjectTable
 public:
   BND_ONXModel_ObjectTable(std::shared_ptr<ONX_Model> m) { m_model = m; }
   BND_UUID AddPoint1(double x, double y, double z);
+  BND_UUID AddPoint6(double x, double y, double z, const class BND_3dmObjectAttributes* attributes);
   BND_UUID AddPoint2(const ON_3dPoint& point) { return AddPoint1(point.x, point.y, point.z); }
-  //Guid AddPoint3(Point3d point, DocObjects.ObjectAttributes attributes)
+  BND_UUID AddPoint3(const ON_3dPoint& point, const class BND_3dmObjectAttributes* attributes) { return AddPoint6(point.x, point.y, point.z, attributes); }
   BND_UUID AddPoint4(const ON_3fPoint& point) { return AddPoint1(point.x, point.y, point.z); }
-  //Guid AddPoint5(Point3f point, DocObjects.ObjectAttributes attributes)
+  BND_UUID AddPoint5(const ON_3fPoint& point, const class BND_3dmObjectAttributes* attributes) { return AddPoint6(point.x, point.y, point.z, attributes); }
   //Guid[] AddPoints1(IEnumerable<Point3d> points)
   //Guid[] AddPoints2(IEnumerable<Point3d> points, DocObjects.ObjectAttributes attributes)
   //Guid[] AddPoints3(IEnumerable<Point3f> points)

--- a/tests/python/test_File3dm_ObjectTable.py
+++ b/tests/python/test_File3dm_ObjectTable.py
@@ -63,7 +63,7 @@ class TestFile3dmObjectTable(unittest.TestCase):
 
         self.assertTrue(qtyObjects == 2 and qtyObjects2 == 1)
 
-        
+
 
 if __name__ == '__main__':
     print("running tests")

--- a/tests/python/test_File3dm_ObjectTable.py
+++ b/tests/python/test_File3dm_ObjectTable.py
@@ -3,6 +3,28 @@ import unittest
 
 #objective: to test that passing a list of points or a Point3dList to the CreateControlPointCurve method returns the same curve
 class TestFile3dmObjectTable(unittest.TestCase):
+    def test_addPoint(self) -> None:
+        """Tests for the `AddPoint` method.
+        """
+        file_3dm = rhino3dm.File3dm()
+
+        # create layers
+        file_3dm.Layers.AddLayer("layer1", (30, 144, 255, 255))
+        file_3dm.Layers.AddLayer("layer2", (255, 215, 0, 255))
+
+        # points added without attributes are added to the current layer, i.e., the first
+        # layer added to the model
+        file_3dm.Objects.AddPoint(rhino3dm.Point3d(0, 0, 0))
+        with self.subTest(msg="AddPoint without attributes"):
+            self.assertEqual(file_3dm.Objects[0].Attributes.LayerIndex, 0)
+
+        # add point with attributes
+        obj_attr = rhino3dm.ObjectAttributes()
+        obj_attr.LayerIndex = 1
+        file_3dm.Objects.AddPoint(rhino3dm.Point3d(1, 1, 0), obj_attr)
+        with self.subTest(msg="AddPoint with attributes"):
+            self.assertEqual(file_3dm.Objects[1].Attributes.LayerIndex, 1)
+
     def test_addPolyline(self):
 
         pointArray = []


### PR DESCRIPTION
Adds three additional overloads of `AddPoint` for Python, mirroring the existing `AddPoint1`, `AddPoint2` and `AddPoint4` which 
 do not take object attributes.

Minimal tests have been added.

Bindings have been added to Python only.

Implements #664. 