### PR TITLE
Update index.rst.txt – add "Python API" to title

### DIFF
--- a/docs/python/api/_sources/index.rst.txt
+++ b/docs/python/api/_sources/index.rst.txt
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to rhino3dm's documentation!
+Welcome to rhino3dm's Python API documentation!
 ====================================
 
 .. toctree::


### PR DESCRIPTION
add "Python API" to the title for clarification and accessibility. Jumping between documentation I find it sometimes hard to know if I am looking at the right rhino python project/API.