### PR TITLE
Fix segfault in InstanceDefinitions.Add() for Python bindings

### DIFF
--- a/src/bindings/bnd_extensions.cpp
+++ b/src/bindings/bnd_extensions.cpp
@@ -1336,15 +1336,24 @@ int BND_File3dmInstanceDefinitionTable::Add(std::wstring name, std::wstring desc
     {
 
 #if defined(ON_PYTHON_COMPILE)
-      BND_GeometryBase g = py::cast<BND_GeometryBase>(geometry[i]);
-      BND_3dmObjectAttributes oa = py::cast<BND_3dmObjectAttributes>(attributes[i]);
+      const BND_GeometryBase& g = geometry[i].cast<const BND_GeometryBase&>();
+      const ON_3dmObjectAttributes* pConstAtts = &ON_3dmObjectAttributes::DefaultAttributes;
+      if (i < count_a)
+      {
+        const BND_3dmObjectAttributes& oa = attributes[i].cast<const BND_3dmObjectAttributes&>();
+        pConstAtts = oa.m_attributes;
+      }
 #else
       BND_GeometryBase g = geometry[i].as<BND_GeometryBase>();
-      BND_3dmObjectAttributes oa = attributes[i].as<BND_3dmObjectAttributes>();
+      const ON_3dmObjectAttributes* pConstAtts = &ON_3dmObjectAttributes::DefaultAttributes;
+      if (i < count_a)
+      {
+        BND_3dmObjectAttributes oa = attributes[i].as<BND_3dmObjectAttributes>();
+        pConstAtts = oa.m_attributes;
+      }
 #endif
 
       const ON_Geometry* pConstGeom = g.GeometryPointer();
-      const ON_3dmObjectAttributes* pConstAtts = i < count_a ? oa.m_attributes : &ON_3dmObjectAttributes::DefaultAttributes;
 
       if (pConstGeom && pConstAtts)
       {
@@ -1368,10 +1377,13 @@ int BND_File3dmInstanceDefinitionTable::Add(std::wstring name, std::wstring desc
             pGeom->Transform(*pXform);
           }
 
-          //have to pass in BND_3dmObjectAttributes to Internal_ONX_Model_AddModelGeometry
-          BND_3dmObjectAttributes _atts;
-          _atts.m_attributes = &atts;
-          ON_UUID uuid = Internal_ONX_Model_AddModelGeometry(m_model.get(), pGeom, &_atts);
+          // Call AddModelGeometryComponent directly to avoid creating a temporary
+          // BND_3dmObjectAttributes which causes memory corruption (the default
+          // constructor wraps a non-geometry ON_Object via CreateManaged, producing
+          // a broken managed component). AddModelGeometryComponent copies both
+          // geometry and attributes internally.
+          ON_ModelComponentReference mcr = m_model->AddModelGeometryComponent(pGeom, &atts);
+          ON_UUID uuid = ON_ModelGeometryComponent::FromModelComponentRef(mcr, &ON_ModelGeometryComponent::Unset)->Id();
           if (ON_UuidIsNotNil(uuid))
             object_uuids.Append(uuid);
 


### PR DESCRIPTION
## Summary

Fixes two memory corruption bugs in `BND_File3dmInstanceDefinitionTable::Add()` that cause non-deterministic segfaults when calling `InstanceDefinitions.Add()` from Python (~60% crash rate, even with a single trivial mesh).

### Bug 1: Value copy corrupts ref counting

`py::cast<BND_GeometryBase>(geometry[i])` copies the wrapper by value, sharing the internal `ON_Object*` with the Python-owned original. When the C++ copy destructs at end of scope, it frees the pointer that Python still owns.

**Fix:** Use `geometry[i].cast<const BND_GeometryBase&>()` to borrow the reference.

### Bug 2: Broken managed component from non-geometry wrapper

`Internal_ONX_Model_AddModelGeometry` was called via a temporary `BND_3dmObjectAttributes` whose default constructor wraps `ON_3dmObjectAttributes` with `CreateManaged()`. This calls `ON_Geometry::Cast()` which returns `nullptr` for non-geometry objects, producing a broken managed component.

**Fix:** Call `m_model->AddModelGeometryComponent(pGeom, &atts)` directly, which copies both geometry and attributes internally.

## Repro

```python
import rhino3dm

f = rhino3dm.File3dm()
m = rhino3dm.Mesh()
m.Vertices.Add(0, 0, 0)
m.Vertices.Add(1, 0, 0)
m.Vertices.Add(1, 1, 0)
m.Faces.AddFace(0, 1, 2, 2)

a = rhino3dm.ObjectAttributes()
f.InstanceDefinitions.Add("test", "", "", "", rhino3dm.Point3d(0, 0, 0), (m,), (a,))
```

Run 10 times -- crashes ~6/10 on rhino3dm 8.17.0. With this fix, 0/10 crashes (tested up to 1000 instances across 20 block definitions).

Fixes #710