### PR TITLE
Add generic SetTexture method for PBR channel textures

### DIFF
--- a/src/bindings/bnd_material.cpp
+++ b/src/bindings/bnd_material.cpp
@@ -125,6 +125,13 @@ bool BND_Material::SetTransparencyTexture2(const BND_Texture& texture)
 }
 
 
+bool BND_Material::SetTexture(const BND_Texture& texture)
+{
+  ON_Texture tx(*texture.m_texture);
+  m_material->DeleteTexture(nullptr, tx.m_type);
+  return m_material->AddTexture(tx);
+}
+
 bool BND_PhysicallyBasedMaterial::Supported() const
 {
   return m_material->IsPhysicallyBased();
@@ -198,6 +205,7 @@ void initMaterialBindings(rh3dmpymodule& m)
     .def("SetTransparencyTexture", &BND_Material::SetTransparencyTexture2, py::arg("texture"))
     .def_property_readonly("PhysicallyBased", &BND_Material::PhysicallyBased)
     .def("ToPhysicallyBased", &BND_Material::ToPhysicallyBased)
+    .def("SetTexture", &BND_Material::SetTexture, py::arg("texture"))
     ;
 }
 

--- a/src/bindings/bnd_material.h
+++ b/src/bindings/bnd_material.h
@@ -81,6 +81,7 @@ public:
   class BND_Texture* GetTransparencyTexture() const;
   bool SetTransparencyTexture(std::wstring filename);
   bool SetTransparencyTexture2(const class BND_Texture& texture);
+  bool SetTexture(const class BND_Texture& texture);
 };
 
 class BND_PhysicallyBasedMaterial


### PR DESCRIPTION
## Summary
- Adds `SetTexture(texture)` method to `Material` that respects the Texture object's `TextureType` property
- Enables setting textures on any PBR channel (Roughness, Metallic, Emission, etc.) which was previously impossible
- Does not modify existing `SetBitmapTexture`/`SetBumpTexture`/etc. methods

## Context
`SetTextureHelper` hardcodes `tx.m_type = ON_Texture::TYPE::bitmap_texture`, overriding whatever type was set on the Texture object. This prevents PBR channel textures from being assigned via the Python API.

Related issue: #719

## Usage
```python
tex = rhino3dm.Texture()
tex.FileName = "roughness.png"
tex.TextureType = rhino3dm.TextureType.PBR_Roughness
mat.SetTexture(tex)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)