### PR TITLE
Add ViewInfo.ConstructionPlane get/set (Fixes RH3DM-197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- (dotnet) `ViewInfo.ConstructionPlane` — get/set a view's construction plane. Views authored with rhino3dm can now set the per-view CPlane (e.g. world ZX for Front, world YZ for Right) instead of leaving the default World-XY; Rhino uses the stored plane on open and does not re-derive it. RH3DM-197.
 - (py) Improved stubs. PR #690 @StudioWEngineers
 
 ## [8.17.0] - 2025.03.12

--- a/src/dotnet/opennurbs/opennurbs_3dm_settings.cs
+++ b/src/dotnet/opennurbs/opennurbs_3dm_settings.cs
@@ -796,6 +796,29 @@ namespace Rhino.DocObjects
         return m_viewport ?? (m_viewport = new ViewportInfo(this));
       }
     }
+
+    /// <summary>
+    /// Gets or sets the construction plane associated with this view. For the standard
+    /// parallel views the plane is the view's camera frame (Top is world XY, Front world ZX,
+    /// Right world YZ); Rhino uses the stored plane when a file or template is opened and does
+    /// not re-derive it, so a view authored with rhino3dm must set this explicitly.
+    /// </summary>
+    /// <since>8.33</since>
+    public Plane ConstructionPlane
+    {
+      get
+      {
+        IntPtr const_ptr_this = ConstPointer();
+        Plane plane = Plane.WorldXY;
+        UnsafeNativeMethods.ON_3dmView_GetConstructionPlane(const_ptr_this, ref plane);
+        return plane;
+      }
+      set
+      {
+        IntPtr ptr_this = NonConstPointer();
+        UnsafeNativeMethods.ON_3dmView_SetConstructionPlane(ptr_this, ref value);
+      }
+    }
     internal IntPtr ConstViewportPointer()
     {
       IntPtr ptr_const_this = ConstPointer();

--- a/src/librhino3dm_native/on_3dm_settings.cpp
+++ b/src/librhino3dm_native/on_3dm_settings.cpp
@@ -147,6 +147,18 @@ RH_C_FUNCTION const ON_Viewport* ON_3dmView_ViewportPointer(const ON_3dmView* pV
   return rc;
 }
 
+RH_C_FUNCTION void ON_3dmView_GetConstructionPlane(const ON_3dmView* pConstView, ON_PLANE_STRUCT* plane)
+{
+  if( pConstView && plane )
+    CopyToPlaneStruct(*plane, pConstView->m_cplane.m_plane);
+}
+
+RH_C_FUNCTION void ON_3dmView_SetConstructionPlane(ON_3dmView* pView, const ON_PLANE_STRUCT* plane)
+{
+  if( pView && plane )
+    pView->m_cplane.m_plane = FromPlaneStruct(*plane);
+}
+
 RH_C_FUNCTION void ON_3dmView_FocalBlurDistance_Set(ON_3dmView* pView, double blur)
 {
 	if (pView)


### PR DESCRIPTION
ViewInfo exposed a view's camera (Viewport) but not its construction plane, so code authoring views with rhino3dm could not set the per-view CPlane and every generated view kept the default World-XY plane — right for Top/Perspective, wrong for Front (world ZX) and Right (world YZ). Rhino uses the stored plane on open and does not re-derive it.

- native: ON_3dmView_GetConstructionPlane / ON_3dmView_SetConstructionPlane over ON_3dmView::m_cplane.m_plane (CopyToPlaneStruct / FromPlaneStruct, same as the sibling ON_ClippingPlaneInfo_GetPlane). methodgen maps ON_PLANE_STRUCT* to `ref Plane`.
- dotnet: ViewInfo.ConstructionPlane { get; set; } returning/taking a Rhino.Geometry.Plane.

9.x counterpart of the same change on 8.x (rhino3dm has no automatic merge between lines). This is the capability behind the RH-97572 template-generation fix, which currently patches the plane into the view record at the chunk level.